### PR TITLE
[FLOWS-1459] Fix: defer db connection close on healthcheck

### DIFF
--- a/server.go
+++ b/server.go
@@ -507,6 +507,7 @@ func (s *server) CheckDB() error {
 	if err != nil {
 		return fmt.Errorf("failed to connect to database: %s", err.Error())
 	}
+	defer db.Close()
 	if err := db.Ping(); err != nil {
 		return fmt.Errorf("failed tot ping database: %s", err.Error())
 	}


### PR DESCRIPTION
Defer `db.Close()` after checking the database health with a new connection, since any new request was causing a new connection to be opened and set to idle in the database indefinitely.