### PR TITLE
Implement contact last seen feature in backend

### DIFF
--- a/backend.go
+++ b/backend.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/gomodule/redigo/redis"
 	"github.com/nyaruka/gocommon/urns"
@@ -64,6 +65,9 @@ type Backend interface {
 
 	// WriteChannelLogs writes the passed in channel logs to our backend
 	WriteChannelLogs(context.Context, []*ChannelLog) error
+
+	// WriteContactLastSeen writes the passed in contact last seen to our backend
+	WriteContactLastSeen(context.Context, Msg, time.Time) error
 
 	// PopNextOutgoingMsg returns the next message that needs to be sent, callers should call MarkOutgoingMsgComplete with the
 	// returned message when they have dealt with the message (regardless of whether it was sent or not)

--- a/backends/rapidpro/backend.go
+++ b/backends/rapidpro/backend.go
@@ -780,6 +780,10 @@ func (b *backend) Start() error {
 	b.contactLastSeenCommitter = batch.NewCommitter("contact last seen committer", b.db, updateContactLastSeenSQL, time.Millisecond*500, b.committerWG,
 		func(err error, value batch.Value) {
 			logrus.WithField("comp", "contact last seen committer").WithError(err).Error("error writing contact last seen")
+			err = courier.WriteToSpool(b.config.SpoolDir, "contact_last_seens", value)
+			if err != nil {
+				logrus.WithField("comp", "contact last seen committer").WithError(err).Error("error writing contact last seen to spool")
+			}
 		})
 	b.contactLastSeenCommitter.Start()
 

--- a/backends/rapidpro/backend.go
+++ b/backends/rapidpro/backend.go
@@ -444,6 +444,36 @@ func (b *backend) WriteChannelLogs(ctx context.Context, logs []*courier.ChannelL
 	return nil
 }
 
+// WriteContactLastSeen writes the passed in contact last seen to our backend
+func (b *backend) WriteContactLastSeen(ctx context.Context, msg courier.Msg, lastSeenOn time.Time) error {
+	timeout, cancel := context.WithTimeout(ctx, backendTimeout)
+	defer cancel()
+
+	dbChannel := msg.Channel().(*DBChannel)
+	contact, err := contactForURN(ctx, b, dbChannel.OrgID(), dbChannel, msg.URN(), "", "")
+	if err != nil {
+		return errors.Wrap(err, "error getting contact")
+	}
+
+	contactLastSeen := &DBContactLastSeen{
+		ID_:         contact.ID(),
+		LastSeenOn_: lastSeenOn,
+	}
+
+	// if we have an id, we can have our batch commit for us
+	if contactLastSeen.ID_ != NilContactID {
+		b.contactLastSeenCommitter.Queue(contactLastSeen)
+	} else {
+		// otherwise, write normally (synchronously)
+		err := writeContactLastSeen(timeout, b, contact, lastSeenOn)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
 // Check if external ID has been seen in a period
 func (b *backend) CheckExternalIDSeen(msg courier.Msg) courier.Msg {
 	var prevUUID = checkExternalIDSeen(b, msg)
@@ -746,11 +776,18 @@ func (b *backend) Start() error {
 		})
 	b.logCommitter.Start()
 
+	// create our contact last seen committer and start it
+	b.contactLastSeenCommitter = batch.NewCommitter("contact last seen committer", b.db, updateContactLastSeenSQL, time.Millisecond*500, b.committerWG,
+		func(err error, value batch.Value) {
+			logrus.WithField("comp", "contact last seen committer").WithError(err).Error("error writing contact last seen")
+		})
+	b.contactLastSeenCommitter.Start()
+
 	// register and start our spool flushers
 	courier.RegisterFlusher(path.Join(b.config.SpoolDir, "msgs"), b.flushMsgFile)
 	courier.RegisterFlusher(path.Join(b.config.SpoolDir, "statuses"), b.flushStatusFile)
 	courier.RegisterFlusher(path.Join(b.config.SpoolDir, "events"), b.flushChannelEventFile)
-
+	courier.RegisterFlusher(path.Join(b.config.SpoolDir, "contact_last_seens"), b.flushContactLastSeenFile)
 	logrus.WithFields(logrus.Fields{
 		"comp":  "backend",
 		"state": "started",
@@ -778,6 +815,11 @@ func (b *backend) Cleanup() error {
 	// stop our log committer
 	if b.logCommitter != nil {
 		b.logCommitter.Stop()
+	}
+
+	// stop our contact last seen committer
+	if b.contactLastSeenCommitter != nil {
+		b.contactLastSeenCommitter.Stop()
 	}
 
 	// wait for them to flush fully
@@ -810,9 +852,10 @@ func newBackend(config *courier.Config) courier.Backend {
 type backend struct {
 	config *courier.Config
 
-	statusCommitter batch.Committer
-	logCommitter    batch.Committer
-	committerWG     *sync.WaitGroup
+	statusCommitter          batch.Committer
+	logCommitter             batch.Committer
+	contactLastSeenCommitter batch.Committer
+	committerWG              *sync.WaitGroup
 
 	db        *sqlx.DB
 	redisPool *redis.Pool

--- a/backends/rapidpro/contact.go
+++ b/backends/rapidpro/contact.go
@@ -86,7 +86,8 @@ SELECT
 	c.created_on, 
 	c.name, 
 	u.id as "urn_id",
-	c.status
+	c.status,
+	c.last_seen_on
 FROM 
 	contacts_contact AS c, 
 	contacts_contacturn AS u 
@@ -106,7 +107,8 @@ SELECT
 	c.created_on, 
 	c.name, 
 	u.id as "urn_id",
-	c.status
+	c.status,
+	c.last_seen_on
 FROM 
 	contacts_contact AS c, 
 	contacts_contacturn AS u 
@@ -145,7 +147,24 @@ func contactForURNTeams(ctx context.Context, b *backend, urn urns.URN, org OrgID
 func contactForURN(ctx context.Context, b *backend, org OrgID, channel *DBChannel, urn urns.URN, auth string, name string) (*DBContact, error) {
 	// try to look up our contact by URN
 	contact := &DBContact{}
-	err := b.db.GetContext(ctx, contact, lookupContactFromURNSQL, urn.Identity(), org)
+
+	// debug query raw sql response
+	rows, err := b.db.QueryxContext(ctx, lookupContactFromURNSQL, urn.Identity(), org)
+	if err != nil {
+		logrus.WithError(err).WithField("urn", urn.Identity()).WithField("org_id", org).Error("error looking up contact")
+		return nil, err
+	}
+	defer rows.Close()
+
+	if rows.Next() {
+		err = rows.Scan(&contact.OrgID_, &contact.ID_, &contact.UUID_, &contact.ModifiedOn_, &contact.CreatedOn_, &contact.Name_, &contact.URNID_, &contact.Status_, &contact.LastSeenOn_)
+		if err != nil {
+			logrus.WithError(err).WithField("urn", urn.Identity()).WithField("org_id", org).Error("error looking up contact")
+			return nil, err
+		}
+	}
+
+	err = b.db.GetContext(ctx, contact, lookupContactFromURNSQL, urn.Identity(), org)
 	if err != nil && err != sql.ErrNoRows {
 		logrus.WithError(err).WithField("urn", urn.Identity()).WithField("org_id", org).Error("error looking up contact")
 		return nil, err
@@ -196,6 +215,7 @@ func contactForURN(ctx context.Context, b *backend, org OrgID, channel *DBChanne
 	contact.UUID_, _ = courier.NewContactUUID(string(uuids.New()))
 	contact.CreatedOn_ = time.Now()
 	contact.ModifiedOn_ = time.Now()
+	contact.LastSeenOn_ = nil
 	contact.IsNew_ = true
 
 	// if we aren't an anonymous org, we want to look up a name if possible and set it
@@ -316,8 +336,9 @@ type DBContact struct {
 
 	URNID_ ContactURNID `db:"urn_id"`
 
-	CreatedOn_  time.Time `db:"created_on"`
-	ModifiedOn_ time.Time `db:"modified_on"`
+	CreatedOn_  time.Time  `db:"created_on"`
+	ModifiedOn_ time.Time  `db:"modified_on"`
+	LastSeenOn_ *time.Time `db:"last_seen_on"`
 
 	CreatedBy_  int `db:"created_by_id"`
 	ModifiedBy_ int `db:"modified_by_id"`
@@ -328,3 +349,6 @@ type DBContact struct {
 
 // UUID returns the UUID for this contact
 func (c *DBContact) UUID() courier.ContactUUID { return c.UUID_ }
+
+// ID returns the ID for this contact
+func (c *DBContact) ID() ContactID { return c.ID_ }

--- a/backends/rapidpro/contact_last_seen.go
+++ b/backends/rapidpro/contact_last_seen.go
@@ -1,0 +1,95 @@
+package rapidpro
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"os"
+	"time"
+
+	"github.com/jmoiron/sqlx"
+	"github.com/nyaruka/courier"
+)
+
+const updateContactLastSeenSQL = `
+UPDATE contacts_contact SET 
+	last_seen_on = c.last_seen_on::timestamp
+FROM
+	(VALUES(:id, :last_seen_on))
+AS
+	c(id, last_seen_on)
+WHERE 
+	contacts_contact.id = c.id::integer
+RETURNING 
+	contacts_contact.id
+`
+
+type DBContactLastSeen struct {
+	ID_         ContactID `json:"id" db:"id"`
+	LastSeenOn_ time.Time `json:"last_seen_on" db:"last_seen_on"`
+}
+
+func (c *DBContactLastSeen) RowID() string {
+	return c.ID_.String()
+}
+
+func writeContactLastSeen(ctx context.Context, b *backend, contact *DBContact, lastSeenOn time.Time) error {
+	contactLastSeen := &DBContactLastSeen{
+		ID_:         contact.ID(),
+		LastSeenOn_: lastSeenOn,
+	}
+
+	err := writeContactLastSeenToDB(ctx, b, contactLastSeen)
+
+	if err == courier.ErrMsgNotFound {
+		return err
+	}
+
+	// failed writing, write to our spool instead
+	if err != nil {
+		err = courier.WriteToSpool(b.config.SpoolDir, "contact_last_seens", contact)
+	}
+
+	return err
+}
+
+func writeContactLastSeenToDB(ctx context.Context, b *backend, contact *DBContactLastSeen) error {
+	var rows *sqlx.Rows
+	var err error
+
+	rows, err = b.db.NamedQueryContext(ctx, updateContactLastSeenSQL, contact)
+
+	if err != nil {
+		return err
+	}
+	defer rows.Close()
+
+	if rows.Next() {
+		rows.Scan(&contact.ID_)
+	} else {
+		return courier.ErrContactNotFound
+	}
+
+	return nil
+}
+
+func (b *backend) flushContactLastSeenFile(filename string, contents []byte) error {
+	contactLastSeen := &DBContactLastSeen{}
+	err := json.Unmarshal(contents, contactLastSeen)
+	if err != nil {
+		log.Printf("ERROR unmarshalling spool file '%s', renaming: %s\n", filename, err)
+		os.Rename(filename, fmt.Sprintf("%s.error", filename))
+		return nil
+	}
+
+	// try to flush to our db
+	err = writeContactLastSeenToDB(context.Background(), b, contactLastSeen)
+
+	// not finding the contact is ok for last seen updates
+	if err == courier.ErrContactNotFound {
+		return nil
+	}
+
+	return err
+}

--- a/backends/rapidpro/schema.sql
+++ b/backends/rapidpro/schema.sql
@@ -37,7 +37,8 @@ CREATE TABLE contacts_contact (
     language character varying(3),
     created_by_id integer NOT NULL,
     modified_by_id integer NOT NULL,
-    org_id integer references orgs_org(id) on delete cascade
+    org_id integer references orgs_org(id) on delete cascade,
+    last_seen_on timestamp with time zone NULL
 );
 
 DROP TABLE IF EXISTS contacts_contacturn CASCADE;

--- a/contact.go
+++ b/contact.go
@@ -1,10 +1,14 @@
 package courier
 
 import (
+	"errors"
 	"strings"
 
 	"github.com/gofrs/uuid"
 )
+
+// ErrContactNotFound is returned when trying to queue the last seen for a Contact that doesn't exit
+var ErrContactNotFound = errors.New("contact not found")
 
 // ContactUUID is our typing of a contact's UUID
 type ContactUUID struct {

--- a/handlers/facebookapp/facebookapp.go
+++ b/handlers/facebookapp/facebookapp.go
@@ -639,6 +639,9 @@ func (h *handler) processCloudWhatsAppPayload(ctx context.Context, channel couri
 				ev := h.Backend().NewIncomingMsg(channel, urn, text).WithReceivedOn(date).WithExternalID(msg.ID).WithContactName(contactNames[msg.From])
 				event := h.Backend().CheckExternalIDSeen(ev)
 
+				// write the contact last seen
+				h.Backend().WriteContactLastSeen(ctx, ev, date)
+
 				// we had an error downloading media
 				if err != nil {
 					courier.LogRequestError(r, channel, err)

--- a/handlers/weniwebchat/weniwebchat.go
+++ b/handlers/weniwebchat/weniwebchat.go
@@ -94,6 +94,9 @@ func (h *handler) receiveMsg(ctx context.Context, channel courier.Channel, w htt
 	date := time.Unix(ts, 0).UTC()
 	msg := h.Backend().NewIncomingMsg(channel, urn, payload.Message.Text).WithReceivedOn(date).WithContactName(payload.From)
 
+	// write the contact last seen
+	h.Backend().WriteContactLastSeen(ctx, msg, date)
+
 	if mediaURL != "" {
 		msg.WithAttachment(mediaURL)
 	}

--- a/sender.go
+++ b/sender.go
@@ -323,8 +323,8 @@ func (w *Sender) sendMessage(msg Msg) {
 		}
 	}
 
-	// we allot 10 seconds to write our status to the db
-	writeCTX, cancel := context.WithTimeout(context.Background(), time.Second*10)
+	// we allot 15 seconds to write our status to the db
+	writeCTX, cancel := context.WithTimeout(context.Background(), time.Second*15)
 	defer cancel()
 
 	err = backend.WriteMsgStatus(writeCTX, status)
@@ -336,6 +336,12 @@ func (w *Sender) sendMessage(msg Msg) {
 	err = backend.WriteChannelLogs(writeCTX, status.Logs())
 	if err != nil {
 		log.WithError(err).Info("error writing msg logs")
+	}
+
+	// write our contact last seen
+	err = backend.WriteContactLastSeen(writeCTX, msg, time.Now())
+	if err != nil {
+		log.WithError(err).Info("error writing contact last seen")
 	}
 
 	// mark our send task as complete


### PR DESCRIPTION
- Added WriteContactLastSeen method to the Backend interface and its implementation in the rapidpro backend.
- Introduced a new DBContactLastSeen struct for managing last seen timestamps in the database.
- Updated the contact schema to include a last_seen_on timestamp field.
- Enhanced the sender logic to write the last seen timestamp when a message is sent.
- Added tests to verify the functionality of the contact last seen feature.