### PR TITLE
Feat: s3 upload metric

### DIFF
--- a/backends/rapidpro/msg.go
+++ b/backends/rapidpro/msg.go
@@ -22,6 +22,7 @@ import (
 	"github.com/gomodule/redigo/redis"
 	"github.com/lib/pq"
 	"github.com/nyaruka/courier"
+	"github.com/nyaruka/courier/metrics"
 	"github.com/nyaruka/courier/queue"
 	"github.com/nyaruka/courier/utils"
 	"github.com/nyaruka/gocommon/urns"
@@ -345,6 +346,9 @@ func downloadMediaToS3(ctx context.Context, b *backend, channel courier.Channel,
 	if err != nil {
 		return "", err
 	}
+
+	// get the file size in bytes and increase our media upload size metric
+	metrics.IncrementMediaUploadSize(len(body))
 
 	// return our new media URL, which is prefixed by our content type
 	return fmt.Sprintf("%s:%s", mimeType, s3URL), nil

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -156,6 +156,12 @@ var new_contacts_by_uuid = promauto.NewGaugeVec(prometheus.GaugeOpts{
 	Help: "The number of new contacts by uuid",
 }, []string{"channel_uuid"})
 
+var media_upload_size = promauto.NewSummary(prometheus.SummaryOpts{
+	Name:       "cr_media_upload_size",
+	Help:       "The size of media uploaded to S3 (bytes)",
+	Objectives: summaryObjectives,
+})
+
 func SetAvailableWorkers(count int) {
 	availableWorkers.Set(float64(count))
 }
@@ -254,4 +260,8 @@ func IncrementNewContactsByUUID(channelUUID uuid.UUID) {
 	if monitorAllChannels || channelsToMonitor[channelUUID] {
 		new_contacts_by_uuid.WithLabelValues(channelUUID.String()).Inc()
 	}
+}
+
+func IncrementMediaUploadSize(size int) {
+	media_upload_size.Observe(float64(size))
 }


### PR DESCRIPTION
This PR introduces a new metric for tracking the size of media uploaded to S3, enhancing the metrics API. The media upload size is now observed in bytes during the media download process, allowing for better monitoring of media handling.