### PR TITLE
feat: Enhance billing configuration and implement MultiBillingClient

### DIFF
--- a/billing/billing.go
+++ b/billing/billing.go
@@ -170,3 +170,31 @@ func (c *rabbitmqRetryClient) SendAsync(msg Message, routingKey string, pre func
 		}
 	}()
 }
+
+// MultiBillingClient sends messages to multiple billing backends simultaneously
+// Used for transitioning between message queue systems (e.g., RabbitMQ to AmazonMQ)
+type MultiBillingClient struct {
+	clients []Client
+}
+
+// NewMultiBillingClient creates a new client that sends to multiple backends
+func NewMultiBillingClient(clients ...Client) Client {
+	return &MultiBillingClient{clients: clients}
+}
+
+func (m *MultiBillingClient) Send(msg Message, routingKey string) error {
+	var lastErr error
+	for _, client := range m.clients {
+		if err := client.Send(msg, routingKey); err != nil {
+			logrus.WithError(err).WithField("routing_key", routingKey).Error("failed to send to billing client")
+			lastErr = err
+		}
+	}
+	return lastErr
+}
+
+func (m *MultiBillingClient) SendAsync(msg Message, routingKey string, pre func(), post func()) {
+	for _, client := range m.clients {
+		client.SendAsync(msg, routingKey, pre, post)
+	}
+}

--- a/cmd/courier/main.go
+++ b/cmd/courier/main.go
@@ -143,12 +143,12 @@ func main() {
 	}
 
 	// AmazonMQ billing client (new)
-	if config.EnableAmazonMQBilling && config.AmazonMQURL != "" {
+	if config.EnableAmazonmqBilling && config.AmazonmqURL != "" {
 		client, err := billing.NewRMQBillingResilientClient(
-			config.AmazonMQURL,
+			config.AmazonmqURL,
 			config.RabbitmqRetryPubAttempts,
 			config.RabbitmqRetryPubDelay,
-			config.AmazonMQBillingExchange,
+			config.AmazonmqBillingExchange,
 		)
 		if err != nil {
 			logrus.WithError(err).Error("Error creating AmazonMQ billing client")

--- a/cmd/courier/main.go
+++ b/cmd/courier/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"errors"
 	"os"
 	"os/signal"
 	"syscall"
@@ -124,14 +123,50 @@ func main() {
 		logrus.Fatalf("Error starting server: %s", err)
 	}
 
-	if config.RabbitmqURL != "" {
-		billingClient, err := billing.NewRMQBillingResilientClient(
-			config.RabbitmqURL, config.RabbitmqRetryPubAttempts, config.RabbitmqRetryPubDelay, config.BillingExchangeName)
-		if err != nil {
-			logrus.Fatalf("Error creating billing RabbitMQ client: %v", err)
-		}
-		server.SetBilling(billingClient)
+	// Initialize billing clients
+	var billingClients []billing.Client
 
+	// RabbitMQ billing client (current)
+	if config.EnableRabbitMQBilling && config.RabbitmqURL != "" {
+		client, err := billing.NewRMQBillingResilientClient(
+			config.RabbitmqURL,
+			config.RabbitmqRetryPubAttempts,
+			config.RabbitmqRetryPubDelay,
+			config.BillingExchangeName,
+		)
+		if err != nil {
+			logrus.WithError(err).Error("Error creating RabbitMQ billing client")
+		} else {
+			billingClients = append(billingClients, client)
+			logrus.Info("RabbitMQ billing client initialized")
+		}
+	}
+
+	// AmazonMQ billing client (new)
+	if config.EnableAmazonMQBilling && config.AmazonMQURL != "" {
+		client, err := billing.NewRMQBillingResilientClient(
+			config.AmazonMQURL,
+			config.RabbitmqRetryPubAttempts,
+			config.RabbitmqRetryPubDelay,
+			config.AmazonMQBillingExchange,
+		)
+		if err != nil {
+			logrus.WithError(err).Error("Error creating AmazonMQ billing client")
+		} else {
+			billingClients = append(billingClients, client)
+			logrus.Info("AmazonMQ billing client initialized")
+		}
+	}
+
+	// Set billing client(s) on server
+	if len(billingClients) > 0 {
+		server.SetBilling(billing.NewMultiBillingClient(billingClients...))
+	} else {
+		logrus.Warn("No billing clients configured")
+	}
+
+	// Templates client (uses RabbitMQ)
+	if config.RabbitmqURL != "" {
 		templatesClient, err := templates.NewRMQTemplateClient(
 			config.RabbitmqURL,
 			config.RabbitmqRetryPubAttempts,
@@ -139,11 +174,12 @@ func main() {
 			config.TemplatesExchangeName,
 		)
 		if err != nil {
-			logrus.Fatalf("Error creating templates RabbitMQ client: %v", err)
+			logrus.WithError(err).Error("Error creating templates RabbitMQ client")
+		} else {
+			server.SetTemplates(templatesClient)
 		}
-		server.SetTemplates(templatesClient)
 	} else {
-		logrus.Error(errors.New("rabbitmq url is not configured"))
+		logrus.Warn("RabbitMQ URL not configured, templates client not initialized")
 	}
 
 	ch := make(chan os.Signal)

--- a/config.go
+++ b/config.go
@@ -59,12 +59,12 @@ type Config struct {
 	BillingExchangeName      string `help:"billing exchange name"`
 
 	// AmazonMQ RabbitMQ configuration
-	AmazonMQURL             string `help:"amazonmq rabbitmq url"`
-	AmazonMQBillingExchange string `help:"amazonmq billing exchange name"`
+	AmazonmqURL             string `help:"amazonmq rabbitmq url"`
+	AmazonmqBillingExchange string `help:"amazonmq billing exchange name"`
 
 	// Feature flags for billing transition
 	EnableRabbitMQBilling bool `help:"enable sending to rabbitmq billing (default true)"`
-	EnableAmazonMQBilling bool `help:"enable sending to amazonmq billing (default false)"`
+	EnableAmazonmqBilling bool `help:"enable sending to amazonmq billing (default false)"`
 
 	EmailProxyURL       string `help:"email proxy url"`
 	EmailProxyAuthToken string `help:"email proxy auth token"`
@@ -109,9 +109,9 @@ func NewConfig() *Config {
 		RabbitmqRetryPubAttempts:     3,
 		RabbitmqRetryPubDelay:        1000,
 		BillingExchangeName:          "msgs.topic",
-		AmazonMQBillingExchange:      "msgs.topic",
+		AmazonmqBillingExchange:      "msgs.topic",
 		EnableRabbitMQBilling:        true,
-		EnableAmazonMQBilling:        false,
+		EnableAmazonmqBilling:        false,
 		EmailProxyURL:                "http://localhost:9090",
 		EmailProxyAuthToken:          "",
 		TemplatesExchangeName:        "templates",

--- a/config.go
+++ b/config.go
@@ -58,6 +58,14 @@ type Config struct {
 	RabbitmqRetryPubDelay    int    `help:"rabbitmq retry delay"`
 	BillingExchangeName      string `help:"billing exchange name"`
 
+	// AmazonMQ RabbitMQ configuration
+	AmazonMQURL             string `help:"amazonmq rabbitmq url"`
+	AmazonMQBillingExchange string `help:"amazonmq billing exchange name"`
+
+	// Feature flags for billing transition
+	EnableRabbitMQBilling bool `help:"enable sending to rabbitmq billing (default true)"`
+	EnableAmazonMQBilling bool `help:"enable sending to amazonmq billing (default false)"`
+
 	EmailProxyURL       string `help:"email proxy url"`
 	EmailProxyAuthToken string `help:"email proxy auth token"`
 
@@ -101,6 +109,9 @@ func NewConfig() *Config {
 		RabbitmqRetryPubAttempts:     3,
 		RabbitmqRetryPubDelay:        1000,
 		BillingExchangeName:          "msgs.topic",
+		AmazonMQBillingExchange:      "msgs.topic",
+		EnableRabbitMQBilling:        true,
+		EnableAmazonMQBilling:        false,
 		EmailProxyURL:                "http://localhost:9090",
 		EmailProxyAuthToken:          "",
 		TemplatesExchangeName:        "templates",


### PR DESCRIPTION
- Added AmazonMQ configuration options to the Config struct, including URL and billing exchange name.
- Introduced feature flags for enabling RabbitMQ and AmazonMQ billing.
- Implemented MultiBillingClient to send messages to multiple billing backends simultaneously, facilitating a transition between RabbitMQ and AmazonMQ.
- Updated main function to initialize and set up billing clients based on the new configuration.