### PR TITLE
fix: Enhance MultiBillingClient to route messages correctly based on RoutingKeyWAC

### DIFF
--- a/billing/billing.go
+++ b/billing/billing.go
@@ -172,29 +172,44 @@ func (c *rabbitmqRetryClient) SendAsync(msg Message, routingKey string, pre func
 }
 
 // MultiBillingClient sends messages to multiple billing backends simultaneously.
-// rabbitMQ is always the first client; otherBackends (e.g. AmazonMQ) do not receive RoutingKeyWAC.
+// rabbitMQ (if non-nil) is the only one that receives RoutingKeyWAC; otherBackends (e.g. AmazonMQ) do not receive WAC.
 type MultiBillingClient struct {
-	clients []Client
+	rabbitMQ Client
+	others   []Client
 }
 
 // NewMultiBillingClient creates a new client that sends to multiple backends.
-// rabbitMQ is always the first backend (sempre RabbitMQ); otherBackends are only used for routing keys different from RoutingKeyWAC.
-// Garante que mensagens com RoutingKeyWAC só vão para o RabbitMQ.
+// rabbitMQ (may be nil) is the backend that receives RoutingKeyWAC; otherBackends only receive other routing keys.
+// If rabbitMQ is nil, WAC messages are not sent to any backend.
 func NewMultiBillingClient(rabbitMQ Client, otherBackends ...Client) Client {
-	clients := make([]Client, 0, 1+len(otherBackends))
-	if rabbitMQ != nil {
-		clients = append(clients, rabbitMQ)
+	others := make([]Client, 0, len(otherBackends))
+	for _, c := range otherBackends {
+		if c != nil {
+			others = append(others, c)
+		}
 	}
-	clients = append(clients, otherBackends...)
-	return &MultiBillingClient{clients: clients}
+	return &MultiBillingClient{rabbitMQ: rabbitMQ, others: others}
 }
 
 func (m *MultiBillingClient) Send(msg Message, routingKey string) error {
 	var lastErr error
-	for i, client := range m.clients {
-		if routingKey == RoutingKeyWAC && i > 0 {
-			continue // só publica no RabbitMQ (primeiro client), não no AmazonMQ
+	if routingKey == RoutingKeyWAC {
+		if m.rabbitMQ != nil {
+			if err := m.rabbitMQ.Send(msg, routingKey); err != nil {
+				logrus.WithError(err).WithField("routing_key", routingKey).Error("failed to send to billing client")
+				lastErr = err
+			}
 		}
+		return lastErr
+	}
+	// Other routing keys: send to RabbitMQ (if present) and to the other backends
+	if m.rabbitMQ != nil {
+		if err := m.rabbitMQ.Send(msg, routingKey); err != nil {
+			logrus.WithError(err).WithField("routing_key", routingKey).Error("failed to send to billing client")
+			lastErr = err
+		}
+	}
+	for _, client := range m.others {
 		if err := client.Send(msg, routingKey); err != nil {
 			logrus.WithError(err).WithField("routing_key", routingKey).Error("failed to send to billing client")
 			lastErr = err
@@ -204,10 +219,16 @@ func (m *MultiBillingClient) Send(msg Message, routingKey string) error {
 }
 
 func (m *MultiBillingClient) SendAsync(msg Message, routingKey string, pre func(), post func()) {
-	for i, client := range m.clients {
-		if routingKey == RoutingKeyWAC && i > 0 {
-			continue
+	if routingKey == RoutingKeyWAC {
+		if m.rabbitMQ != nil {
+			m.rabbitMQ.SendAsync(msg, routingKey, pre, post)
 		}
+		return
+	}
+	if m.rabbitMQ != nil {
+		m.rabbitMQ.SendAsync(msg, routingKey, pre, post)
+	}
+	for _, client := range m.others {
 		client.SendAsync(msg, routingKey, pre, post)
 	}
 }

--- a/billing/billing.go
+++ b/billing/billing.go
@@ -172,23 +172,23 @@ func (c *rabbitmqRetryClient) SendAsync(msg Message, routingKey string, pre func
 }
 
 // MultiBillingClient sends messages to multiple billing backends simultaneously.
-// rabbitMQ (if non-nil) is the only one that receives RoutingKeyWAC; otherBackends (e.g. AmazonMQ) do not receive WAC.
+// rabbitMQ (if non-nil) is the only one that receives RoutingKeyWAC; defaultBackends (e.g. AmazonMQ) do not receive WAC.
 type MultiBillingClient struct {
-	rabbitMQ Client
-	others   []Client
+	rabbitMQ        Client
+	defaultBackends []Client
 }
 
 // NewMultiBillingClient creates a new client that sends to multiple backends.
-// rabbitMQ (may be nil) is the backend that receives RoutingKeyWAC; otherBackends only receive other routing keys.
+// rabbitMQ (may be nil) is the backend that receives RoutingKeyWAC; defaultBackends only receive other routing keys.
 // If rabbitMQ is nil, WAC messages are not sent to any backend.
-func NewMultiBillingClient(rabbitMQ Client, otherBackends ...Client) Client {
-	others := make([]Client, 0, len(otherBackends))
-	for _, c := range otherBackends {
+func NewMultiBillingClient(rabbitMQ Client, defaultBackends ...Client) Client {
+	defaults := make([]Client, 0, len(defaultBackends))
+	for _, c := range defaultBackends {
 		if c != nil {
-			others = append(others, c)
+			defaults = append(defaults, c)
 		}
 	}
-	return &MultiBillingClient{rabbitMQ: rabbitMQ, others: others}
+	return &MultiBillingClient{rabbitMQ: rabbitMQ, defaultBackends: defaults}
 }
 
 func (m *MultiBillingClient) Send(msg Message, routingKey string) error {
@@ -209,7 +209,7 @@ func (m *MultiBillingClient) Send(msg Message, routingKey string) error {
 			lastErr = err
 		}
 	}
-	for _, client := range m.others {
+	for _, client := range m.defaultBackends {
 		if err := client.Send(msg, routingKey); err != nil {
 			logrus.WithError(err).WithField("routing_key", routingKey).Error("failed to send to billing client")
 			lastErr = err
@@ -228,7 +228,7 @@ func (m *MultiBillingClient) SendAsync(msg Message, routingKey string, pre func(
 	if m.rabbitMQ != nil {
 		m.rabbitMQ.SendAsync(msg, routingKey, pre, post)
 	}
-	for _, client := range m.others {
+	for _, client := range m.defaultBackends {
 		client.SendAsync(msg, routingKey, pre, post)
 	}
 }

--- a/billing/billing.go
+++ b/billing/billing.go
@@ -171,20 +171,30 @@ func (c *rabbitmqRetryClient) SendAsync(msg Message, routingKey string, pre func
 	}()
 }
 
-// MultiBillingClient sends messages to multiple billing backends simultaneously
-// Used for transitioning between message queue systems (e.g., RabbitMQ to AmazonMQ)
+// MultiBillingClient sends messages to multiple billing backends simultaneously.
+// rabbitMQ is always the first client; otherBackends (e.g. AmazonMQ) do not receive RoutingKeyWAC.
 type MultiBillingClient struct {
 	clients []Client
 }
 
-// NewMultiBillingClient creates a new client that sends to multiple backends
-func NewMultiBillingClient(clients ...Client) Client {
+// NewMultiBillingClient creates a new client that sends to multiple backends.
+// rabbitMQ is always the first backend (sempre RabbitMQ); otherBackends are only used for routing keys different from RoutingKeyWAC.
+// Garante que mensagens com RoutingKeyWAC só vão para o RabbitMQ.
+func NewMultiBillingClient(rabbitMQ Client, otherBackends ...Client) Client {
+	clients := make([]Client, 0, 1+len(otherBackends))
+	if rabbitMQ != nil {
+		clients = append(clients, rabbitMQ)
+	}
+	clients = append(clients, otherBackends...)
 	return &MultiBillingClient{clients: clients}
 }
 
 func (m *MultiBillingClient) Send(msg Message, routingKey string) error {
 	var lastErr error
-	for _, client := range m.clients {
+	for i, client := range m.clients {
+		if routingKey == RoutingKeyWAC && i > 0 {
+			continue // só publica no RabbitMQ (primeiro client), não no AmazonMQ
+		}
 		if err := client.Send(msg, routingKey); err != nil {
 			logrus.WithError(err).WithField("routing_key", routingKey).Error("failed to send to billing client")
 			lastErr = err
@@ -194,7 +204,10 @@ func (m *MultiBillingClient) Send(msg Message, routingKey string) error {
 }
 
 func (m *MultiBillingClient) SendAsync(msg Message, routingKey string, pre func(), post func()) {
-	for _, client := range m.clients {
+	for i, client := range m.clients {
+		if routingKey == RoutingKeyWAC && i > 0 {
+			continue
+		}
 		client.SendAsync(msg, routingKey, pre, post)
 	}
 }

--- a/billing/billing_test.go
+++ b/billing/billing_test.go
@@ -352,8 +352,30 @@ func TestMultiBillingClientSendAsync(t *testing.T) {
 	assert.Equal(t, 2, postCalled) // Called once per client
 }
 
+func TestMultiBillingClientRoutingKeyWACOnlyFirstClient(t *testing.T) {
+	client1 := &mockBillingClient{}
+	client2 := &mockBillingClient{}
+	multiClient := NewMultiBillingClient(client1, client2)
+
+	msg := NewMessage(
+		"telegram:123456789", "uuid", "John", "channel-uuid", "msg-id", "2024-01-01",
+		"O", "TG", "hello", nil, nil, false, "", "sent",
+	)
+
+	// RoutingKeyWAC: só o primeiro client (RabbitMQ) recebe; segundo (AmazonMQ) não
+	err := multiClient.Send(msg, RoutingKeyWAC)
+	assert.NoError(t, err)
+	assert.Equal(t, 1, client1.sendCalled)
+	assert.Equal(t, 0, client2.sendCalled)
+
+	client1.sendCalled = 0
+	multiClient.SendAsync(msg, RoutingKeyWAC, nil, nil)
+	assert.Equal(t, 1, client1.sendAsyncCalled)
+	assert.Equal(t, 0, client2.sendAsyncCalled)
+}
+
 func TestMultiBillingClientEmpty(t *testing.T) {
-	multiClient := NewMultiBillingClient()
+	multiClient := NewMultiBillingClient(nil)
 
 	msg := NewMessage(
 		"telegram:123456789",

--- a/billing/billing_test.go
+++ b/billing/billing_test.go
@@ -362,7 +362,7 @@ func TestMultiBillingClientRoutingKeyWACOnlyFirstClient(t *testing.T) {
 		"O", "TG", "hello", nil, nil, false, "", "sent",
 	)
 
-	// RoutingKeyWAC: só o primeiro client (RabbitMQ) recebe; segundo (AmazonMQ) não
+	// RoutingKeyWAC: only the first client (RabbitMQ) receives; second (AmazonMQ) does not
 	err := multiClient.Send(msg, RoutingKeyWAC)
 	assert.NoError(t, err)
 	assert.Equal(t, 1, client1.sendCalled)

--- a/cmd/courier/main.go
+++ b/cmd/courier/main.go
@@ -123,9 +123,9 @@ func main() {
 		logrus.Fatalf("Error starting server: %s", err)
 	}
 
-	// Initialize billing clients: RabbitMQ (only it receives WAC) and other backends (e.g. AmazonMQ)
+	// Initialize billing clients: RabbitMQ (only it receives WAC) and default backends (e.g. AmazonMQ)
 	var rabbitMQBilling billing.Client
-	var otherBillingClients []billing.Client
+	var defaultBillingClients []billing.Client
 
 	// RabbitMQ billing client (current)
 	if config.EnableRabbitMQBilling && config.RabbitmqURL != "" {
@@ -154,14 +154,14 @@ func main() {
 		if err != nil {
 			logrus.WithError(err).Error("Error creating AmazonMQ billing client")
 		} else {
-			otherBillingClients = append(otherBillingClients, client)
+			defaultBillingClients = append(defaultBillingClients, client)
 			logrus.Info("AmazonMQ billing client initialized")
 		}
 	}
 
 	// Set billing client(s) on server
-	if rabbitMQBilling != nil || len(otherBillingClients) > 0 {
-		server.SetBilling(billing.NewMultiBillingClient(rabbitMQBilling, otherBillingClients...))
+	if rabbitMQBilling != nil || len(defaultBillingClients) > 0 {
+		server.SetBilling(billing.NewMultiBillingClient(rabbitMQBilling, defaultBillingClients...))
 	} else {
 		logrus.Warn("No billing clients configured")
 	}

--- a/cmd/courier/main.go
+++ b/cmd/courier/main.go
@@ -123,8 +123,9 @@ func main() {
 		logrus.Fatalf("Error starting server: %s", err)
 	}
 
-	// Initialize billing clients
-	var billingClients []billing.Client
+	// Initialize billing clients: RabbitMQ (only it receives WAC) and other backends (e.g. AmazonMQ)
+	var rabbitMQBilling billing.Client
+	var otherBillingClients []billing.Client
 
 	// RabbitMQ billing client (current)
 	if config.EnableRabbitMQBilling && config.RabbitmqURL != "" {
@@ -137,12 +138,12 @@ func main() {
 		if err != nil {
 			logrus.WithError(err).Error("Error creating RabbitMQ billing client")
 		} else {
-			billingClients = append(billingClients, client)
+			rabbitMQBilling = client
 			logrus.Info("RabbitMQ billing client initialized")
 		}
 	}
 
-	// AmazonMQ billing client (new)
+	// AmazonMQ billing client (new) — does not receive RoutingKeyWAC
 	if config.EnableAmazonmqBilling && config.AmazonmqURL != "" {
 		client, err := billing.NewRMQBillingResilientClient(
 			config.AmazonmqURL,
@@ -153,14 +154,14 @@ func main() {
 		if err != nil {
 			logrus.WithError(err).Error("Error creating AmazonMQ billing client")
 		} else {
-			billingClients = append(billingClients, client)
+			otherBillingClients = append(otherBillingClients, client)
 			logrus.Info("AmazonMQ billing client initialized")
 		}
 	}
 
 	// Set billing client(s) on server
-	if len(billingClients) > 0 {
-		server.SetBilling(billing.NewMultiBillingClient(billingClients[0], billingClients[1:]...))
+	if rabbitMQBilling != nil || len(otherBillingClients) > 0 {
+		server.SetBilling(billing.NewMultiBillingClient(rabbitMQBilling, otherBillingClients...))
 	} else {
 		logrus.Warn("No billing clients configured")
 	}

--- a/cmd/courier/main.go
+++ b/cmd/courier/main.go
@@ -160,7 +160,7 @@ func main() {
 
 	// Set billing client(s) on server
 	if len(billingClients) > 0 {
-		server.SetBilling(billing.NewMultiBillingClient(billingClients...))
+		server.SetBilling(billing.NewMultiBillingClient(billingClients[0], billingClients[1:]...))
 	} else {
 		logrus.Warn("No billing clients configured")
 	}


### PR DESCRIPTION
- Problem: A `queue not bound` error started occurring. We identified that the error occurs because the WAC message routing key (used by Chats) does not exist in AmazonMQ. Therefore, we implemented a fix to prevent messages from being sent to AmazonMQ using that key.