### PR TITLE
feat: Implement payment notification handling for WhatsApp Cloud API

### DIFF
--- a/handlers/facebookapp/facebookapp.go
+++ b/handlers/facebookapp/facebookapp.go
@@ -265,6 +265,7 @@ type moPayload struct {
 							LastFourDigits   string `json:"last_four_digits"`
 							CredentialID     string `json:"credential_id"`
 						} `json:"payment_method,omitempty"`
+						PaymentNotification interface{} `json:"payment_notification,omitempty"`
 					} `json:"interactive,omitempty"`
 					Contacts []struct {
 						Name struct {
@@ -476,6 +477,13 @@ func processWACPaymentMethodMetadata(paymentMethod interface{}) *wacMessageMetad
 	return &wacMessageMetadata{
 		Key:   "payment_method",
 		Value: paymentMethod,
+	}
+}
+
+func processWACPaymentNotificationMetadata(paymentNotification interface{}) *wacMessageMetadata {
+	return &wacMessageMetadata{
+		Key:   "payment_notification",
+		Value: paymentNotification,
 	}
 }
 
@@ -857,6 +865,8 @@ func (h *handler) processCloudWhatsAppPayload(ctx context.Context, channel couri
 					text = strings.Join(phones, ", ")
 				} else if msg.Type == "interactive" && msg.Interactive.Type == "payment_method" {
 					text = ""
+				} else if msg.Type == "interactive" && msg.Interactive.Type == "payment_notification" {
+					text = ""
 				} else if msg.Type == "reaction" {
 					data = append(data, courier.NewInfoData("ignoring echo reaction message"))
 					continue
@@ -890,6 +900,8 @@ func (h *handler) processCloudWhatsAppPayload(ctx context.Context, channel couri
 					}
 				} else if msg.Interactive.Type == "payment_method" {
 					wacMeta = processWACPaymentMethodMetadata(msg.Interactive.PaymentMethod)
+				} else if msg.Interactive.Type == "payment_notification" {
+					wacMeta = processWACPaymentNotificationMetadata(msg.Interactive.PaymentNotification)
 				}
 
 				if wacMeta != nil {

--- a/handlers/facebookapp/facebookapp_test.go
+++ b/handlers/facebookapp/facebookapp_test.go
@@ -456,6 +456,24 @@ var testCasesWAC = []ChannelHandleTestCase{
 			},
 		}),
 		PrepRequest: addValidSignatureWAC},
+	{Label: "Receive Payment Notification WAC", URL: wacReceiveURL, Data: string(courier.ReadFile("./testdata/wac/paymentNotificationWAC.json")), Status: 200, Response: "Handled", NoQueueErrorCheck: true, NoInvalidChannelCheck: true,
+		URN: Sp("whatsapp:5678"), ExternalID: Sp("external_id"), Date: Tp(time.Date(2016, 1, 30, 1, 57, 9, 0, time.UTC)), Metadata: Jp(map[string]interface{}{
+			"payment_notification": map[string]interface{}{
+				"reference_id":    "ref_123456",
+				"transaction_id":  "txn_abc789",
+				"payment_status":  "captured",
+				"payer_name":      "Kerry Fisher",
+			},
+			"overwrite_message": map[string]interface{}{
+				"payment_notification": map[string]interface{}{
+					"reference_id":    "ref_123456",
+					"transaction_id":  "txn_abc789",
+					"payment_status":  "captured",
+					"payer_name":      "Kerry Fisher",
+				},
+			},
+		}),
+		PrepRequest: addValidSignatureWAC},
 	{Label: "Receive Reaction Message", URL: wacReceiveURL, Data: string(courier.ReadFile("./testdata/wac/reactionWAC.json")), Status: 200, Response: `"ignoring echo reaction message"`, PrepRequest: addValidSignatureWAC},
 }
 

--- a/handlers/facebookapp/testdata/wac/paymentNotificationWAC.json
+++ b/handlers/facebookapp/testdata/wac/paymentNotificationWAC.json
@@ -1,0 +1,45 @@
+{
+    "object": "whatsapp_business_account",
+    "entry": [
+        {
+            "id": "8856996819413533",
+            "changes": [
+                {
+                    "value": {
+                        "messaging_product": "whatsapp",
+                        "metadata": {
+                            "display_phone_number": "+250 788 123 200",
+                            "phone_number_id": "12345"
+                        },
+                        "contacts": [
+                            {
+                                "profile": {
+                                    "name": "Kerry Fisher"
+                                },
+                                "wa_id": "5678"
+                            }
+                        ],
+                        "messages": [
+                            {
+                                "from": "5678",
+                                "id": "external_id",
+                                "interactive": {
+                                    "type": "payment_notification",
+                                    "payment_notification": {
+                                        "reference_id": "ref_123456",
+                                        "transaction_id": "txn_abc789",
+                                        "payment_status": "captured",
+                                        "payer_name": "Kerry Fisher"
+                                    }
+                                },
+                                "timestamp": "1454119029",
+                                "type": "interactive"
+                            }
+                        ]
+                    },
+                    "field": "messages"
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
- Added support for processing payment notifications in the WhatsApp Cloud API by introducing a new `PaymentNotification` field in the `moPayload` struct.
- Created a new function `processWACPaymentNotificationMetadata` to handle payment notification metadata.
- Added a test case for receiving payment notifications in `facebookapp_test.go`.
- Included a sample payment notification JSON file for testing purposes.