### PR TITLE
feat: Add BroadcastID to TemplateMessage and related functions for improved message tracking

### DIFF
--- a/WENI-CHANGELOG.md
+++ b/WENI-CHANGELOG.md
@@ -1,3 +1,7 @@
+1.51.0
+----------
+ * feat: Add BroadcastID to TemplateMessage and related functions for improved message tracking
+
 1.50.1
 ----------
  * feat: check if org is not ab2(is_multi_agents) before publish billing message event

--- a/backends/rapidpro/backend_test.go
+++ b/backends/rapidpro/backend_test.go
@@ -888,6 +888,28 @@ func (ts *BackendTestSuite) TestMsgStatus() {
 	ts.NoError(tx.Commit())
 }
 
+func (ts *BackendTestSuite) TestStatusMetadataReturning() {
+	ctx := context.Background()
+	channel := ts.getChannel("KN", "dbc126ed-66bc-4e28-b67b-81dc3327c95d")
+
+	expectedMetadata := `{"templating":{"template":{"name":"hi","uuid":"abc","category":"MARKETING"}}}`
+
+	// seed metadata on the existing test message (id 10000, external_id ext1)
+	_, err := ts.b.db.ExecContext(ctx, `UPDATE msgs_msg SET metadata = $1 WHERE id = 10000`, expectedMetadata)
+	ts.NoError(err)
+
+	// hit the external-id path so the new RETURNING clause runs
+	status := ts.b.NewMsgStatusForExternalID(channel, "ext1", courier.MsgDelivered)
+	ts.NoError(ts.b.WriteMsgStatus(ctx, status))
+
+	ts.JSONEq(expectedMetadata, string(status.Metadata()))
+
+	// id-path statuses should still work and leave Metadata nil (no RETURNING change there)
+	statusByID := ts.b.NewMsgStatusForID(channel, courier.NewMsgID(10000), courier.MsgRead)
+	ts.NoError(ts.b.WriteMsgStatus(ctx, statusByID))
+	ts.Nil(statusByID.Metadata())
+}
+
 func (ts *BackendTestSuite) TestContactLastSeenWithName() {
 	ctx := context.Background()
 	channel := ts.getChannel("TG", "dbc126ed-66bc-4e28-b67b-81dc3327c98a")

--- a/backends/rapidpro/status.go
+++ b/backends/rapidpro/status.go
@@ -199,9 +199,17 @@ func writeMsgStatusToDB(ctx context.Context, b *backend, status *DBMsgStatus) er
 	// scan the id (and metadata, when available) of the msg that was updated
 	if rows.Next() {
 		if status.ID() != courier.NilMsgID {
-			rows.Scan(&status.ID_)
+			if scanErr := rows.Scan(&status.ID_); scanErr != nil {
+				return scanErr
+			}
 		} else {
-			rows.Scan(&status.ID_, &status.Metadata_)
+			var metadataBytes []byte
+			if scanErr := rows.Scan(&status.ID_, &metadataBytes); scanErr != nil {
+				return scanErr
+			}
+			if len(metadataBytes) > 0 {
+				status.Metadata_ = json.RawMessage(metadataBytes)
+			}
 		}
 	} else {
 		return courier.ErrMsgNotFound

--- a/backends/rapidpro/status.go
+++ b/backends/rapidpro/status.go
@@ -176,7 +176,7 @@ UPDATE msgs_msg SET
 WHERE 
 	msgs_msg.id = (SELECT msgs_msg.id FROM msgs_msg WHERE msgs_msg.external_id = :external_id AND msgs_msg.channel_id = :channel_id AND msgs_msg.direction = 'O' LIMIT 1)
 RETURNING 
-	msgs_msg.id
+	msgs_msg.id, msgs_msg.metadata
 `
 
 // writeMsgStatusToDB writes the passed in msg status to our db
@@ -196,9 +196,13 @@ func writeMsgStatusToDB(ctx context.Context, b *backend, status *DBMsgStatus) er
 	}
 	defer rows.Close()
 
-	// scan and read the id of the msg that was updated
+	// scan the id (and metadata, when available) of the msg that was updated
 	if rows.Next() {
-		rows.Scan(&status.ID_)
+		if status.ID() != courier.NilMsgID {
+			rows.Scan(&status.ID_)
+		} else {
+			rows.Scan(&status.ID_, &status.Metadata_)
+		}
 	} else {
 		return courier.ErrMsgNotFound
 	}
@@ -306,6 +310,7 @@ type DBMsgStatus struct {
 	ExternalID_  string                 `json:"external_id,omitempty"    db:"external_id"`
 	Status_      courier.MsgStatusValue `json:"status"                   db:"status"`
 	ModifiedOn_  time.Time              `json:"modified_on"              db:"modified_on"`
+	Metadata_    json.RawMessage        `json:"-"                         db:"metadata"`
 
 	logs []*courier.ChannelLog
 }
@@ -359,3 +364,5 @@ func (s *DBMsgStatus) AddLog(log *courier.ChannelLog) { s.logs = append(s.logs, 
 
 func (s *DBMsgStatus) Status() courier.MsgStatusValue          { return s.Status_ }
 func (s *DBMsgStatus) SetStatus(status courier.MsgStatusValue) { s.Status_ = status }
+
+func (s *DBMsgStatus) Metadata() json.RawMessage { return s.Metadata_ }

--- a/billing/billing.go
+++ b/billing/billing.go
@@ -151,8 +151,11 @@ func (c *rabbitmqRetryClient) Send(msg Message, routingKey string) error {
 		return errors.Wrap(err, "failed to publish msg to billing")
 	}
 	logrus.WithFields(logrus.Fields{
-		"routing_key": routingKey,
-		"msg":         string(msgMarshalled),
+		"exchange_name": c.exchangeName,
+		"routing_key":   routingKey,
+		"msg":           string(msgMarshalled),
+		"contact_urn":   msg.ContactURN,
+		"status":        msg.Status,
 	}).Info("message published to billing")
 	return nil
 }

--- a/handlers/facebookapp/facebookapp.go
+++ b/handlers/facebookapp/facebookapp.go
@@ -88,24 +88,46 @@ var waTemplateTypeMapping = map[string]string{
 // inspecting the metadata of the original outbound message. It returns the
 // mapped template type (one of the values in waTemplateTypeMapping) or an
 // empty string when the message is not a template, the category is missing,
-// or the category is unknown — preserving the previous "only known categories
-// trigger a publish" semantics.
-func waTemplateTypeFromMetadata(metadata json.RawMessage) string {
+// the category is unknown, or the metadata is not a parseable JSON object.
+//
+// The helper is intentionally lenient: the metadata column is loosely typed
+// upstream, so anything that isn't a JSON object containing a usable
+// templating block (nil, empty string, "null", scalars, arrays, malformed
+// JSON, raw text, etc.) is treated as "not a template" — the caller skips the
+// template-status publish in that case. A defer/recover guards against any
+// unexpected panic in the JSON parser so a single bad row never takes down
+// the webhook handler.
+func waTemplateTypeFromMetadata(metadata json.RawMessage) (templateType string) {
+	defer func() {
+		if r := recover(); r != nil {
+			logrus.WithField("recover", r).Warn("recovered from panic in waTemplateTypeFromMetadata; skipping template-status publish")
+			templateType = ""
+		}
+	}()
+
 	if len(metadata) == 0 {
 		return ""
 	}
-	if _, _, _, err := jsonparser.Get(metadata, "templating"); err != nil {
+	// only JSON objects can carry a templating block — short-circuit on
+	// anything else (null, scalars, arrays, raw text) before invoking the
+	// JSON parser.
+	trimmed := bytes.TrimSpace(metadata)
+	if len(trimmed) == 0 || trimmed[0] != '{' {
 		return ""
 	}
-	category, err := jsonparser.GetString(metadata, "templating", "template", "category")
+
+	if _, _, _, err := jsonparser.Get(trimmed, "templating"); err != nil {
+		return ""
+	}
+	category, err := jsonparser.GetString(trimmed, "templating", "template", "category")
 	if err != nil || category == "" {
 		return ""
 	}
-	templateType, ok := waTemplateTypeMapping[strings.ToLower(category)]
+	mapped, ok := waTemplateTypeMapping[strings.ToLower(category)]
 	if !ok {
 		return ""
 	}
-	return templateType
+	return mapped
 }
 
 var waIgnoreStatuses = map[string]bool{

--- a/handlers/facebookapp/facebookapp.go
+++ b/handlers/facebookapp/facebookapp.go
@@ -994,20 +994,20 @@ func (h *handler) processCloudWhatsAppPayload(ctx context.Context, channel couri
 							billingMsg := billing.NewMessage(
 								string(urn.Identity()),
 								"",
-							contactNames[status.RecipientID],
-							channel.UUID().String(),
-							status.ID,
-							time.Now().Format(time.RFC3339),
-							"",
-							channel.ChannelType().String(),
-							"",
-							nil,
-							nil,
-							false,
-							"",
-							string(msgStatus),
-							0,
-						)
+								contactNames[status.RecipientID],
+								channel.UUID().String(),
+								status.ID,
+								time.Now().Format(time.RFC3339),
+								"",
+								channel.ChannelType().String(),
+								"",
+								nil,
+								nil,
+								false,
+								"",
+								string(msgStatus),
+								0,
+							)
 							h.Server().Billing().SendAsync(billingMsg, billing.RoutingKeyUpdate, nil, nil)
 						}
 					}
@@ -1026,6 +1026,7 @@ func (h *handler) processCloudWhatsAppPayload(ctx context.Context, channel couri
 								status.ID,
 								string(msgStatus),
 								templateType,
+								0,
 							)
 							h.Server().Templates().SendAsync(statusMsg, templates.RoutingKeyStatus, nil, nil)
 						}

--- a/handlers/facebookapp/facebookapp.go
+++ b/handlers/facebookapp/facebookapp.go
@@ -84,6 +84,30 @@ var waTemplateTypeMapping = map[string]string{
 	"utility":        "utility",
 }
 
+// waTemplateTypeFromMetadata extracts the template type for a status update by
+// inspecting the metadata of the original outbound message. It returns the
+// mapped template type (one of the values in waTemplateTypeMapping) or an
+// empty string when the message is not a template, the category is missing,
+// or the category is unknown — preserving the previous "only known categories
+// trigger a publish" semantics.
+func waTemplateTypeFromMetadata(metadata json.RawMessage) string {
+	if len(metadata) == 0 {
+		return ""
+	}
+	if _, _, _, err := jsonparser.Get(metadata, "templating"); err != nil {
+		return ""
+	}
+	category, err := jsonparser.GetString(metadata, "templating", "template", "category")
+	if err != nil || category == "" {
+		return ""
+	}
+	templateType, ok := waTemplateTypeMapping[strings.ToLower(category)]
+	if !ok {
+		return ""
+	}
+	return templateType
+}
+
 var waIgnoreStatuses = map[string]bool{
 	"deleted": true,
 }
@@ -1013,9 +1037,8 @@ func (h *handler) processCloudWhatsAppPayload(ctx context.Context, channel couri
 					}
 				}
 
-				if status.Conversation != nil {
-					templateType, isTemplateMessage := waTemplateTypeMapping[status.Conversation.Origin.Type]
-					if isTemplateMessage && h.Server().Templates() != nil {
+				if h.Server().Templates() != nil {
+					if templateType := waTemplateTypeFromMetadata(event.Metadata()); templateType != "" {
 						urn, err := urns.NewWhatsAppURN(status.RecipientID)
 						if err != nil {
 							handlers.WriteAndLogRequestError(ctx, h, channel, w, r, err)

--- a/handlers/facebookapp/facebookapp_test.go
+++ b/handlers/facebookapp/facebookapp_test.go
@@ -1847,16 +1847,34 @@ func TestWaTemplateTypeFromMetadata(t *testing.T) {
 		metadata string
 		expected string
 	}{
-		{"empty metadata", ``, ""},
-		{"nil metadata bytes", `null`, ""},
-		{"non-template metadata", `{"topic":"event","text_language":"eng"}`, ""},
-		{"templating without category", `{"templating":{"template":{"name":"hi","uuid":"abc"},"language":"eng"}}`, ""},
+		// happy paths
 		{"category MARKETING", `{"templating":{"template":{"name":"hi","uuid":"abc","category":"MARKETING"},"language":"eng"}}`, "marketing"},
 		{"category Utility mixed-case", `{"templating":{"template":{"name":"hi","uuid":"abc","category":"Utility"}}}`, "utility"},
 		{"category authentication lowercase", `{"templating":{"template":{"name":"otp","uuid":"abc","category":"authentication"}}}`, "authentication"},
+		{"object with leading whitespace", "  \t\n{\"templating\":{\"template\":{\"name\":\"hi\",\"uuid\":\"abc\",\"category\":\"MARKETING\"}}}", "marketing"},
+
+		// known no-publish cases
+		{"non-template metadata", `{"topic":"event","text_language":"eng"}`, ""},
+		{"templating without category", `{"templating":{"template":{"name":"hi","uuid":"abc"},"language":"eng"}}`, ""},
 		{"unknown category", `{"templating":{"template":{"name":"hi","uuid":"abc","category":"SERVICE"}}}`, ""},
 		{"empty category string", `{"templating":{"template":{"name":"hi","uuid":"abc","category":""}}}`, ""},
-		{"malformed JSON", `{"templating":`, ""},
+
+		// metadata column that isn't a JSON object — must skip without error
+		{"empty metadata", ``, ""},
+		{"whitespace only", `   `, ""},
+		{"literal null", `null`, ""},
+		{"literal true", `true`, ""},
+		{"literal number", `42`, ""},
+		{"json string", `"hello"`, ""},
+		{"json array", `[{"templating":{"template":{"category":"MARKETING"}}}]`, ""},
+		{"raw plain text", `hello world`, ""},
+
+		// malformed json inside an object — must not panic, must skip
+		{"malformed JSON truncated", `{"templating":`, ""},
+		{"malformed JSON unbalanced", `{"templating":{"template":{}`, ""},
+		{"malformed JSON garbage after object", `{} not json`, ""},
+		{"category not a string", `{"templating":{"template":{"category":123}}}`, ""},
+		{"category as object", `{"templating":{"template":{"category":{"name":"MARKETING"}}}}`, ""},
 	}
 
 	for _, c := range cases {

--- a/handlers/facebookapp/facebookapp_test.go
+++ b/handlers/facebookapp/facebookapp_test.go
@@ -1840,3 +1840,29 @@ func TestSendingWCD(t *testing.T) {
 
 	RunChannelSendTestCases(t, ChannelWCD, newWACDemoHandler("WCD", "WhatsApp Cloud Demo"), SendTestCasesWCD, nil)
 }
+
+func TestWaTemplateTypeFromMetadata(t *testing.T) {
+	cases := []struct {
+		label    string
+		metadata string
+		expected string
+	}{
+		{"empty metadata", ``, ""},
+		{"nil metadata bytes", `null`, ""},
+		{"non-template metadata", `{"topic":"event","text_language":"eng"}`, ""},
+		{"templating without category", `{"templating":{"template":{"name":"hi","uuid":"abc"},"language":"eng"}}`, ""},
+		{"category MARKETING", `{"templating":{"template":{"name":"hi","uuid":"abc","category":"MARKETING"},"language":"eng"}}`, "marketing"},
+		{"category Utility mixed-case", `{"templating":{"template":{"name":"hi","uuid":"abc","category":"Utility"}}}`, "utility"},
+		{"category authentication lowercase", `{"templating":{"template":{"name":"otp","uuid":"abc","category":"authentication"}}}`, "authentication"},
+		{"unknown category", `{"templating":{"template":{"name":"hi","uuid":"abc","category":"SERVICE"}}}`, ""},
+		{"empty category string", `{"templating":{"template":{"name":"hi","uuid":"abc","category":""}}}`, ""},
+		{"malformed JSON", `{"templating":`, ""},
+	}
+
+	for _, c := range cases {
+		t.Run(c.label, func(t *testing.T) {
+			got := waTemplateTypeFromMetadata(json.RawMessage(c.metadata))
+			assert.Equal(t, c.expected, got)
+		})
+	}
+}

--- a/sender.go
+++ b/sender.go
@@ -347,6 +347,7 @@ func (w *Sender) sendMessage(msg Msg) {
 				templateLanguage,
 				templateNamespace,
 				templateVariables,
+				msg.BroadcastID(),
 			)
 			w.foreman.server.Templates().SendAsync(templateMsg, templates.RoutingKeySend, nil, nil)
 		}

--- a/status.go
+++ b/status.go
@@ -1,6 +1,10 @@
 package courier
 
-import "github.com/nyaruka/gocommon/urns"
+import (
+	"encoding/json"
+
+	"github.com/nyaruka/gocommon/urns"
+)
 
 // MsgStatusValue is the status of a message
 type MsgStatusValue string
@@ -38,6 +42,11 @@ type MsgStatus interface {
 
 	Status() MsgStatusValue
 	SetStatus(MsgStatusValue)
+
+	// Metadata returns the metadata of the underlying message row, when the
+	// backend populates it (e.g. via the RETURNING clause of the status update).
+	// Returns nil when not available.
+	Metadata() json.RawMessage
 
 	Logs() []*ChannelLog
 	AddLog(log *ChannelLog)

--- a/templates/templates.go
+++ b/templates/templates.go
@@ -34,6 +34,7 @@ type TemplateMessage struct {
 	TemplateVariables []string `json:"template_variables,omitempty"`
 	Status            string   `json:"status,omitempty"`
 	TemplateType      string   `json:"template_type,omitempty"`
+	BroadcastID       int64    `json:"broadcast_id,omitempty"`
 }
 
 // NewTemplateMessage cria uma nova mensagem de template
@@ -41,7 +42,7 @@ func NewTemplateMessage(
 	contactURN, contactUUID, channelUUID, messageID, messageDate,
 	direction, channelType, text,
 	templateName, templateUUID, templateLanguage, templateNamespace string,
-	templateVariables []string) TemplateMessage {
+	templateVariables []string, broadcastID int64) TemplateMessage {
 
 	return TemplateMessage{
 		ContactURN:        contactURN,
@@ -57,12 +58,13 @@ func NewTemplateMessage(
 		TemplateLanguage:  templateLanguage,
 		TemplateNamespace: templateNamespace,
 		TemplateVariables: templateVariables,
+		BroadcastID:       broadcastID,
 	}
 }
 
 // NewTemplateStatusMessage cria uma nova mensagem de status de template
 func NewTemplateStatusMessage(
-	contactURN, channelUUID, messageID, status, templateType string) TemplateMessage {
+	contactURN, channelUUID, messageID, status, templateType string, broadcastID int64) TemplateMessage {
 
 	return TemplateMessage{
 		ContactURN:   contactURN,
@@ -71,6 +73,7 @@ func NewTemplateStatusMessage(
 		MessageDate:  time.Now().Format(time.RFC3339),
 		Status:       status,
 		TemplateType: templateType,
+		BroadcastID:  broadcastID,
 	}
 }
 

--- a/templates/templates.go
+++ b/templates/templates.go
@@ -178,6 +178,14 @@ func (c *rabbitmqClient) send(msg TemplateMessage, routingKey string) error {
 	if err != nil {
 		return errors.Wrap(err, "failed to publish template message")
 	}
+	logrus.WithFields(logrus.Fields{
+		"exchange_name": c.exchangeName,
+		"routing_key":   routingKey,
+		"msg":           string(msgMarshalled),
+		"contact_urn":   msg.ContactURN,
+		"template_name": msg.TemplateName,
+		"status":        msg.Status,
+	}).Info("message published to templates")
 	return nil
 }
 

--- a/templates/templates_test.go
+++ b/templates/templates_test.go
@@ -111,6 +111,7 @@ func TestTemplateResilientClient(t *testing.T) {
 		"pt_BR",
 		"namespace-12345",
 		[]string{"João", "ativa"},
+		42,
 	)
 
 	templateClient, err := NewRMQTemplateClient(connURL, 3, 1000, templatesTestExchangeName)
@@ -154,6 +155,7 @@ func TestTemplateResilientClient(t *testing.T) {
 	assert.Equal(t, msg.TemplateUUID, receivedMsg.TemplateUUID)
 	assert.Equal(t, msg.TemplateLanguage, receivedMsg.TemplateLanguage)
 	assert.ElementsMatch(t, msg.TemplateVariables, receivedMsg.TemplateVariables)
+	assert.Equal(t, int64(42), receivedMsg.BroadcastID)
 }
 
 func TestTemplateResilientClientSendStatus(t *testing.T) {
@@ -177,6 +179,7 @@ func TestTemplateResilientClientSendStatus(t *testing.T) {
 		"msg-123456",
 		"delivered",
 		"marketing",
+		99,
 	)
 
 	templateClient, err := NewRMQTemplateClient(connURL, 3, 1000, templatesTestExchangeName)
@@ -217,6 +220,7 @@ func TestTemplateResilientClientSendStatus(t *testing.T) {
 	wg.Wait()
 	assert.Equal(t, msg.MessageID, receivedMsg.MessageID)
 	assert.Equal(t, msg.Status, receivedMsg.Status)
+	assert.Equal(t, int64(99), receivedMsg.BroadcastID)
 }
 
 func TestTemplateResilientClientSendAsync(t *testing.T) {
@@ -248,6 +252,7 @@ func TestTemplateResilientClientSendAsync(t *testing.T) {
 		"pt_BR",
 		"namespace-12345",
 		[]string{"João", "ativa"},
+		7,
 	)
 
 	templateClient, err := NewRMQTemplateClient(connURL, 3, 1000, templatesTestExchangeName)
@@ -329,6 +334,7 @@ func TestTemplateResilientClientSendAsyncWithPanic(t *testing.T) {
 		"pt_BR",
 		"namespace-12345",
 		[]string{"João", "ativa"},
+		0,
 	)
 
 	templateClient, err := NewRMQTemplateClient(connURL, 3, 1000, templatesTestExchangeName)

--- a/test.go
+++ b/test.go
@@ -1184,6 +1184,7 @@ type mockMsgStatus struct {
 	externalID string
 	status     MsgStatusValue
 	createdOn  time.Time
+	metadata   json.RawMessage
 
 	logs []*ChannelLog
 }
@@ -1212,6 +1213,9 @@ func (m *mockMsgStatus) SetExternalID(id string) { m.externalID = id }
 
 func (m *mockMsgStatus) Status() MsgStatusValue          { return m.status }
 func (m *mockMsgStatus) SetStatus(status MsgStatusValue) { m.status = status }
+
+func (m *mockMsgStatus) Metadata() json.RawMessage              { return m.metadata }
+func (m *mockMsgStatus) SetMetadata(metadata json.RawMessage)   { m.metadata = metadata }
 
 func (m *mockMsgStatus) Logs() []*ChannelLog    { return m.logs }
 func (m *mockMsgStatus) AddLog(log *ChannelLog) { m.logs = append(m.logs, log) }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Medium risk because it changes message status DB update semantics (adds `metadata` to `RETURNING` for external-id updates) and alters WhatsApp template-status publishing logic based on persisted metadata, which could affect downstream integrations if parsing/mapping is incorrect.
> 
> **Overview**
> Adds `BroadcastID` to `templates.TemplateMessage` and propagates it through `NewTemplateMessage`/`NewTemplateStatusMessage`, the sender publish path, and template client tests to improve template message tracking.
> 
> Enhances RapidPro status updates for external IDs to `RETURNING` the message `metadata` and exposes it via a new `MsgStatus.Metadata()` API, then updates the WhatsApp Cloud webhook handler to derive template status type from that stored metadata (with robust parsing + tests) instead of conversation-origin fields.
> 
> Improves observability by expanding RabbitMQ publish logs for billing and templates messages (includes exchange name plus key identifying fields).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7f1c3e940ad0c4fa2c9107efd2dabef99dd01875. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->