### PR TITLE
fix: Update gocommon dependency to version 1.17.0

### DIFF
--- a/WENI-CHANGELOG.md
+++ b/WENI-CHANGELOG.md
@@ -1,3 +1,7 @@
+1.53.1
+----------
+ * fix: Update gocommon dependency to version 1.17.0
+
 1.53.0
 ----------
  * feat: Enhance WhatsApp message handling with support for BSUID and username, including new test cases for various message formats

--- a/go.mod
+++ b/go.mod
@@ -86,4 +86,4 @@ go 1.24.0
 
 toolchain go1.24.12
 
-replace github.com/nyaruka/gocommon => github.com/weni-ai/gocommon v1.17.0-weni-stg
+replace github.com/nyaruka/gocommon => github.com/weni-ai/gocommon v1.17.0

--- a/go.sum
+++ b/go.sum
@@ -148,8 +148,8 @@ github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
-github.com/weni-ai/gocommon v1.17.0-weni-stg h1:XHGJW7dR8GhANZg30OSsdmy42VVfdvUx2hKUihgw1ZE=
-github.com/weni-ai/gocommon v1.17.0-weni-stg/go.mod h1:pk8L9T79VoKO8OWTiZbtUutFPI3sGGKB5u8nNWDKuGE=
+github.com/weni-ai/gocommon v1.17.0 h1:R5rA9+PbZg7u9XZCyu57EaO5MSM9fKxxkMrgbjj6LXs=
+github.com/weni-ai/gocommon v1.17.0/go.mod h1:pk8L9T79VoKO8OWTiZbtUutFPI3sGGKB5u8nNWDKuGE=
 go.uber.org/automaxprocs v1.6.0 h1:O3y2/QNTOdbF+e/dpXNNW7Rx2hZ4sTIPyybbxyNqTUs=
 go.uber.org/automaxprocs v1.6.0/go.mod h1:ifeIMSnPZuznNm6jmdzmU3/bfk01Fe2fotchwEFJ8r8=
 go.uber.org/goleak v1.2.1 h1:NBol2c7O1ZokfZ0LEU9K6Whx/KnwvepVetCUhtKja4A=


### PR DESCRIPTION
Correct the gocommon version by removing the staging version.