### PR TITLE
fix: Update WhatsApp message handling to improve URN assignment logic

### DIFF
--- a/WENI-CHANGELOG.md
+++ b/WENI-CHANGELOG.md
@@ -1,3 +1,7 @@
+1.59.1
+----------
+ * fix: Update WhatsApp message handling to improve URN assignment logic
+
 1.59.0
 ----------
  * feat: Add support for 'request_contact_info' interaction type in WhatsApp message handling and update related tests

--- a/handlers/facebookapp/facebookapp.go
+++ b/handlers/facebookapp/facebookapp.go
@@ -970,34 +970,34 @@ func (h *handler) processCloudWhatsAppPayload(ctx context.Context, channel couri
 				var urn urns.URN
 				var secondaryURN urns.URN
 				if msg.From != "" && msg.FromUserID != "" {
-					// Both phone and BSUID present: prefer the URN that already has a contact
-					// so we don't create a duplicate and steal the other URN from the existing one.
+					// Both phone number and BSUID are present. The phone number is always the
+					// contact's preferred URN, so the message is attributed to it: writing the
+					// message promotes its URN to the contact's default (highest priority). The
+					// BSUID is kept as a secondary URN so the contact stays reachable if the
+					// phone number changes.
 					phoneURN, phoneErr := urns.NewWhatsAppURN(msg.From)
-					bsuidURN, bsuidErr := urns.NewWhatsAppURN(msg.FromUserID)
 					if phoneErr != nil {
 						return nil, nil, handlers.WriteAndLogRequestError(ctx, h, channel, w, r, phoneErr)
 					}
+					bsuidURN, bsuidErr := urns.NewWhatsAppURN(msg.FromUserID)
 					if bsuidErr != nil {
 						return nil, nil, handlers.WriteAndLogRequestError(ctx, h, channel, w, r, bsuidErr)
 					}
 
-					// Check BSUID first: in steady state (contact already has both URNs, or
-					// only the BSUID) this single lookup is enough, sparing the phone query.
-					// The phone lookup only runs for the transitional/edge cases where the
-					// BSUID isn't linked to a contact yet.
-					if _, bsuidContactErr := h.Backend().FindContact(ctx, channel, bsuidURN); bsuidContactErr == nil {
-						// Existing BSUID contact (username-first / phone-number-sharing flow)
-						urn = bsuidURN
-						secondaryURN = phoneURN
-					} else if _, phoneContactErr := h.Backend().FindContact(ctx, channel, phoneURN); phoneContactErr == nil {
-						// Existing phone contact receiving BSUID for the first time
-						urn = phoneURN
-						secondaryURN = bsuidURN
-					} else {
-						// Neither exists yet: prefer BSUID as stable identity, phone as secondary
-						urn = bsuidURN
-						secondaryURN = phoneURN
+					// If a contact already exists only under the BSUID (phone-number-sharing
+					// flow, where the phone number is revealed for the first time), attach the
+					// phone number to that existing contact before writing the message so we
+					// don't create a duplicate contact.
+					if bsuidContact, bsuidContactErr := h.Backend().FindContact(ctx, channel, bsuidURN); bsuidContactErr == nil {
+						if _, phoneContactErr := h.Backend().FindContact(ctx, channel, phoneURN); phoneContactErr != nil {
+							if _, addErr := h.Backend().AddURNtoContact(ctx, channel, bsuidContact, phoneURN); addErr != nil {
+								courier.LogRequestError(r, channel, fmt.Errorf("unable to add phone URN to existing BSUID contact: %v", addErr))
+							}
+						}
 					}
+
+					urn = phoneURN
+					secondaryURN = bsuidURN
 				} else if msg.From != "" {
 					urn, err = urns.NewWhatsAppURN(msg.From)
 				} else if msg.FromUserID != "" {

--- a/handlers/facebookapp/facebookapp_test.go
+++ b/handlers/facebookapp/facebookapp_test.go
@@ -515,14 +515,14 @@ var testCasesWAC = []ChannelHandleTestCase{
 		Text: Sp("Hello World"), URN: Sp("whatsapp:US.13491208655302741918"), ExternalID: Sp("external_id"), Date: Tp(time.Date(2016, 1, 30, 1, 57, 9, 0, time.UTC)),
 		PrepRequest: addValidSignatureWAC},
 	{Label: "Receive Message Phone and BSUID", URL: wacReceiveURL, Data: string(courier.ReadFile("./testdata/wac/helloBSUIDWithPhone.json")), Status: 200, Response: "Handled", NoQueueErrorCheck: true, NoInvalidChannelCheck: true,
-		Text: Sp("Hello World"), URN: Sp("whatsapp:US.13491208655302741918"), ExternalID: Sp("external_id"), Date: Tp(time.Date(2016, 1, 30, 1, 57, 9, 0, time.UTC)),
+		Text: Sp("Hello World"), URN: Sp("whatsapp:5678"), ExternalID: Sp("external_id"), Date: Tp(time.Date(2016, 1, 30, 1, 57, 9, 0, time.UTC)),
 		ContactURNs: map[string]bool{
 			"whatsapp:US.13491208655302741918": true,
 			"whatsapp:5678":                   true,
 		},
 		PrepRequest: addValidSignatureWAC},
 	{Label: "Receive Message Phone and BSUID Existing BSUID Contact", URL: wacReceiveURL, Data: string(courier.ReadFile("./testdata/wac/helloBSUIDWithPhone.json")), Status: 200, Response: "Handled", NoQueueErrorCheck: true, NoInvalidChannelCheck: true,
-		Text: Sp("Hello World"), URN: Sp("whatsapp:US.13491208655302741918"), ExternalID: Sp("external_id"), Date: Tp(time.Date(2016, 1, 30, 1, 57, 9, 0, time.UTC)),
+		Text: Sp("Hello World"), URN: Sp("whatsapp:5678"), ExternalID: Sp("external_id"), Date: Tp(time.Date(2016, 1, 30, 1, 57, 9, 0, time.UTC)),
 		ContactURNs: map[string]bool{
 			"whatsapp:US.13491208655302741918": true,
 			"whatsapp:5678":                   true,
@@ -544,7 +544,7 @@ var testCasesWAC = []ChannelHandleTestCase{
 		},
 		PrepRequest: addValidSignatureWAC},
 	{Label: "Receive Contact Request Response Phone and BSUID Existing BSUID Contact", URL: wacReceiveURL, Data: string(courier.ReadFile("./testdata/wac/helloBSUIDWithPhoneContactRequest.json")), Status: 200, Response: "Handled", NoQueueErrorCheck: true, NoInvalidChannelCheck: true,
-		Text: Sp("+250 788 123 456"), URN: Sp("whatsapp:US.13491208655302741918"), ExternalID: Sp("external_id"), Date: Tp(time.Date(2016, 1, 30, 1, 57, 9, 0, time.UTC)),
+		Text: Sp("+250 788 123 456"), URN: Sp("whatsapp:5678"), ExternalID: Sp("external_id"), Date: Tp(time.Date(2016, 1, 30, 1, 57, 9, 0, time.UTC)),
 		ContactURNs: map[string]bool{
 			"whatsapp:US.13491208655302741918": true,
 			"whatsapp:5678":                   true,
@@ -565,7 +565,7 @@ var testCasesWAC = []ChannelHandleTestCase{
 	{Label: "Receive User ID Update", URL: wacReceiveURL, Data: string(courier.ReadFile("./testdata/wac/userIDUpdateWAC.json")), Status: 200, Response: `"user_id_update: BSUID updated from US.13491208655302741918 to US.98765432100000000001"`,
 		PrepRequest: addValidSignatureWAC},
 	{Label: "Receive Message Phone BSUID and Parent BSUID", URL: wacReceiveURL, Data: string(courier.ReadFile("./testdata/wac/helloParentBSUID.json")), Status: 200, Response: "Handled", NoQueueErrorCheck: true, NoInvalidChannelCheck: true,
-		Text: Sp("Hello World"), URN: Sp("whatsapp:US.13491208655302741918"), ExternalID: Sp("external_id"), Date: Tp(time.Date(2016, 1, 30, 1, 57, 9, 0, time.UTC)),
+		Text: Sp("Hello World"), URN: Sp("whatsapp:5678"), ExternalID: Sp("external_id"), Date: Tp(time.Date(2016, 1, 30, 1, 57, 9, 0, time.UTC)),
 		ContactURNs: map[string]bool{
 			"whatsapp:US.13491208655302741918": true,
 			"whatsapp:5678":                   true,


### PR DESCRIPTION
- Adjusted test cases to use a new URN format for WhatsApp contacts.
- Enhanced the logic for processing messages with both phone numbers and BSUIDs to prevent duplicate contacts and ensure proper attribution of messages to the preferred URN.