### PR TITLE
Feat/enhance email thread

### DIFF
--- a/backend.go
+++ b/backend.go
@@ -125,6 +125,15 @@ type Backend interface {
 	// fall back gracefully.
 	LookupMsgByExternalID(context.Context, Channel, string) (Msg, error)
 
+	// LookupMsgByID returns the message with the given Temba id. Used by the
+	// email handler when response_to_id is set but response_to_external_id is not.
+	LookupMsgByID(context.Context, MsgID) (Msg, error)
+
+	// LookupLastMsgWithExternalID returns the most recent visible message on the
+	// channel for the contact URN that carries a non-empty external_id. Used by the
+	// email handler to thread replies when mailroom did not set response_to_external_id.
+	LookupLastMsgWithExternalID(context.Context, Channel, urns.URN) (Msg, error)
+
 	UpdateChannelConfig(context.Context, Channel, map[string]interface{}) error
 
 	UpdateChannelConfigByWabaID(context.Context, string, map[string]interface{}) error

--- a/backends/rapidpro/backend.go
+++ b/backends/rapidpro/backend.go
@@ -935,7 +935,7 @@ func (b *backend) LookupMsgByExternalID(ctx context.Context, channel courier.Cha
 	if !ok {
 		return nil, fmt.Errorf("LookupMsgByExternalID requires a *DBChannel, got %T", channel)
 	}
-	return GetMsgByExternalID(b, dbChannel.ID(), externalID)
+	return GetMsgByExternalID(ctx, b, dbChannel.ID(), externalID)
 }
 
 // LookupMsgByID resolves a Temba message id to its row, including metadata.
@@ -943,7 +943,7 @@ func (b *backend) LookupMsgByID(ctx context.Context, id courier.MsgID) (courier.
 	if id == courier.NilMsgID {
 		return nil, courier.ErrMsgNotFound
 	}
-	return GetMsgByIDWithMetadata(b, id)
+	return GetMsgByIDWithMetadata(ctx, b, id)
 }
 
 // LookupLastMsgWithExternalID returns the latest visible message on the channel
@@ -956,7 +956,7 @@ func (b *backend) LookupLastMsgWithExternalID(ctx context.Context, channel couri
 	if !ok {
 		return nil, fmt.Errorf("LookupLastMsgWithExternalID requires a *DBChannel, got %T", channel)
 	}
-	return GetLastMsgWithExternalID(b, dbChannel.ID(), string(urn.Identity()))
+	return GetLastMsgWithExternalID(ctx, b, dbChannel.ID(), string(urn.Identity()))
 }
 
 func (b *backend) GetProjectUUIDFromChannelUUID(ctx context.Context, channelUUID courier.ChannelUUID) (string, error) {

--- a/backends/rapidpro/backend.go
+++ b/backends/rapidpro/backend.go
@@ -938,6 +938,27 @@ func (b *backend) LookupMsgByExternalID(ctx context.Context, channel courier.Cha
 	return GetMsgByExternalID(b, dbChannel.ID(), externalID)
 }
 
+// LookupMsgByID resolves a Temba message id to its row, including metadata.
+func (b *backend) LookupMsgByID(ctx context.Context, id courier.MsgID) (courier.Msg, error) {
+	if id == courier.NilMsgID {
+		return nil, courier.ErrMsgNotFound
+	}
+	return GetMsgByIDWithMetadata(b, id)
+}
+
+// LookupLastMsgWithExternalID returns the latest visible message on the channel
+// for the contact that carries an external_id (e.g. email Message-ID).
+func (b *backend) LookupLastMsgWithExternalID(ctx context.Context, channel courier.Channel, urn urns.URN) (courier.Msg, error) {
+	if urn == urns.NilURN {
+		return nil, courier.ErrMsgNotFound
+	}
+	dbChannel, ok := channel.(*DBChannel)
+	if !ok {
+		return nil, fmt.Errorf("LookupLastMsgWithExternalID requires a *DBChannel, got %T", channel)
+	}
+	return GetLastMsgWithExternalID(b, dbChannel.ID(), string(urn.Identity()))
+}
+
 func (b *backend) GetProjectUUIDFromChannelUUID(ctx context.Context, channelUUID courier.ChannelUUID) (string, error) {
 	return getProjectUUIDFromChannelUUID(ctx, b.db, channelUUID.String())
 }

--- a/backends/rapidpro/backend_test.go
+++ b/backends/rapidpro/backend_test.go
@@ -953,6 +953,47 @@ func (ts *BackendTestSuite) TestLookupMsgByExternalIDWithJSONBMetadata() {
 	ts.JSONEq(expectedMetadata, string(msg.Metadata()), "metadata should round-trip unchanged from jsonb column")
 }
 
+// TestLookupLastMsgWithExternalIDWithTextMetadata reproduces the production
+// failure where msgs_msg.metadata is text and sqlx Get cannot scan a string
+// into *json.RawMessage — the exact error seen when resolveParentExternalID
+// falls back to LookupLastMsgWithExternalID for email replies.
+func (ts *BackendTestSuite) TestLookupLastMsgWithExternalIDWithTextMetadata() {
+	ctx := context.Background()
+	channel := ts.getChannel("KN", "dbc126ed-66bc-4e28-b67b-81dc3327c95d")
+
+	// 10002 is the highest-id visible msg with a non-empty external_id for URN 1000.
+	// Seed uuid (NULL in testdata.sql) and text metadata like production.
+	expectedMetadata := `{"email":{"subject":"Meu Produto","references":["<produto@example.com>"]}}`
+	_, err := ts.b.db.ExecContext(ctx, `
+		UPDATE msgs_msg
+		SET metadata = $1, uuid = 'a984069d-0008-4d8c-a772-b14a8a6acc99'
+		WHERE id = 10002`, expectedMetadata)
+	ts.Require().NoError(err)
+
+	urn, err := urns.NewURNFromParts(urns.TelScheme, "+12067799192", "", "")
+	ts.Require().NoError(err)
+
+	msg, err := ts.b.LookupLastMsgWithExternalID(ctx, channel, urn)
+	ts.NoError(err, "LookupLastMsgWithExternalID must scan text metadata without error")
+	if !ts.NotNil(msg) {
+		return
+	}
+	ts.Equal("ext2", msg.ExternalID())
+	ts.JSONEq(expectedMetadata, string(msg.Metadata()))
+
+	// same scan path via id lookup
+	_, err = ts.b.db.ExecContext(ctx, `
+		UPDATE msgs_msg
+		SET metadata = $1, uuid = 'a984069d-0008-4d8c-a772-b14a8a6acc98'
+		WHERE id = 10000`, expectedMetadata)
+	ts.Require().NoError(err)
+	byID, err := ts.b.LookupMsgByID(ctx, courier.NewMsgID(10000))
+	ts.NoError(err, "LookupMsgByID must scan text metadata without error")
+	if ts.NotNil(byID) {
+		ts.JSONEq(expectedMetadata, string(byID.Metadata()))
+	}
+}
+
 func (ts *BackendTestSuite) TestContactLastSeenWithName() {
 	ctx := context.Background()
 	channel := ts.getChannel("TG", "dbc126ed-66bc-4e28-b67b-81dc3327c98a")

--- a/backends/rapidpro/msg.go
+++ b/backends/rapidpro/msg.go
@@ -887,7 +887,8 @@ type msgRow interface {
 // msgs_msg schema differs from a naive struct mapping in two important ways:
 //   - metadata is "text" rather than jsonb, so the pq driver returns a
 //     string (not []byte) which can't be scanned into *json.RawMessage
-//     directly.
+//     directly. Scanning into sql.NullString works for both text and jsonb
+//     (jsonb is accepted as string by database/sql).
 //   - several columns (high_priority, modified_on, queued_on, sent_on) are
 //     nullable, but the DBMsg fields are plain bool / time.Time, which fail
 //     the scan when the database delivers NULL.
@@ -900,11 +901,11 @@ func scanDBMsgWithMetadata(row msgRow) (*DBMsg, error) {
 	m := &DBMsg{}
 
 	var (
-		highPriority  sql.NullBool
-		modifiedOn    sql.NullTime
-		queuedOn      sql.NullTime
-		sentOn        sql.NullTime
-		metadataBytes []byte
+		highPriority sql.NullBool
+		modifiedOn   sql.NullTime
+		queuedOn     sql.NullTime
+		sentOn       sql.NullTime
+		metadataStr  sql.NullString
 	)
 
 	err := row.Scan(
@@ -912,7 +913,7 @@ func scanDBMsgWithMetadata(row msgRow) (*DBMsg, error) {
 		&m.MessageCount_, &m.ErrorCount_, &highPriority, &m.Status_, &m.Visibility_,
 		&m.ExternalID_, &m.ChannelID_, &m.ContactID_, &m.ContactURNID_,
 		&m.CreatedOn_, &modifiedOn, &queuedOn, &sentOn,
-		&metadataBytes,
+		&metadataStr,
 	)
 	if err != nil {
 		return nil, err
@@ -931,8 +932,8 @@ func scanDBMsgWithMetadata(row msgRow) (*DBMsg, error) {
 		t := sentOn.Time
 		m.SentOn_ = &t
 	}
-	if len(metadataBytes) > 0 {
-		raw := json.RawMessage(metadataBytes)
+	if metadataStr.Valid && metadataStr.String != "" {
+		raw := json.RawMessage(metadataStr.String)
 		m.Metadata_ = &raw
 	}
 	return m, nil

--- a/backends/rapidpro/msg.go
+++ b/backends/rapidpro/msg.go
@@ -252,6 +252,70 @@ ORDER BY id DESC
 LIMIT 1
 `
 
+const selectMsgByIDWithMetadataSQL = `
+SELECT
+	id,
+	uuid,
+	org_id,
+	direction,
+	text,
+	attachments,
+	msg_count,
+	error_count,
+	high_priority,
+	status,
+	visibility,
+	external_id,
+	channel_id,
+	contact_id,
+	contact_urn_id,
+	created_on,
+	modified_on,
+	queued_on,
+	sent_on,
+	metadata
+FROM
+	msgs_msg
+WHERE
+	id = $1
+`
+
+const selectLastMsgWithExternalIDSQL = `
+SELECT
+	m.id,
+	m.uuid,
+	m.org_id,
+	m.direction,
+	m.text,
+	m.attachments,
+	m.msg_count,
+	m.error_count,
+	m.high_priority,
+	m.status,
+	m.visibility,
+	m.external_id,
+	m.channel_id,
+	m.contact_id,
+	m.contact_urn_id,
+	m.created_on,
+	m.modified_on,
+	m.queued_on,
+	m.sent_on,
+	m.metadata
+FROM
+	msgs_msg m
+INNER JOIN contacts_contacturn u ON m.contact_urn_id = u.id
+WHERE
+	m.channel_id = $1
+	AND u.identity = $2
+	AND m.external_id IS NOT NULL
+	AND m.external_id != ''
+	AND m.visibility = 'V'
+ORDER BY
+	m.id DESC
+LIMIT 1
+`
+
 const selectChannelSQL = `
 SELECT
 	org_id,
@@ -799,6 +863,28 @@ func GetMsgByExternalID(b *backend, channelID courier.ChannelID, externalID stri
 		return nil, err
 	}
 
+	return m, nil
+}
+
+// GetMsgByIDWithMetadata returns the message row for the given id including
+// metadata, or sql.ErrNoRows when none matches.
+func GetMsgByIDWithMetadata(b *backend, id courier.MsgID) (*DBMsg, error) {
+	m := &DBMsg{}
+	err := b.db.Get(m, selectMsgByIDWithMetadataSQL, id)
+	if err != nil {
+		return nil, err
+	}
+	return m, nil
+}
+
+// GetLastMsgWithExternalID returns the most recent visible message on the
+// channel for the contact URN that has a non-empty external_id.
+func GetLastMsgWithExternalID(b *backend, channelID courier.ChannelID, urnIdentity string) (*DBMsg, error) {
+	m := &DBMsg{}
+	err := b.db.Get(m, selectLastMsgWithExternalIDSQL, channelID, urnIdentity)
+	if err != nil {
+		return nil, err
+	}
 	return m, nil
 }
 

--- a/backends/rapidpro/msg.go
+++ b/backends/rapidpro/msg.go
@@ -857,22 +857,22 @@ func GetMsgByUUID(b *backend, uuid string) (*DBMsg, error) {
 
 // GetMsgByExternalID returns the most recent message on the passed channel
 // with the given external_id, or sql.ErrNoRows when none matches.
-func GetMsgByExternalID(b *backend, channelID courier.ChannelID, externalID string) (*DBMsg, error) {
-	row := b.db.QueryRowxContext(context.Background(), selectMsgByExternalIDSQL, channelID, externalID)
+func GetMsgByExternalID(ctx context.Context, b *backend, channelID courier.ChannelID, externalID string) (*DBMsg, error) {
+	row := b.db.QueryRowxContext(ctx, selectMsgByExternalIDSQL, channelID, externalID)
 	return scanDBMsgWithMetadata(row)
 }
 
 // GetMsgByIDWithMetadata returns the message row for the given id including
 // metadata, or sql.ErrNoRows when none matches.
-func GetMsgByIDWithMetadata(b *backend, id courier.MsgID) (*DBMsg, error) {
-	row := b.db.QueryRowxContext(context.Background(), selectMsgByIDWithMetadataSQL, id)
+func GetMsgByIDWithMetadata(ctx context.Context, b *backend, id courier.MsgID) (*DBMsg, error) {
+	row := b.db.QueryRowxContext(ctx, selectMsgByIDWithMetadataSQL, id)
 	return scanDBMsgWithMetadata(row)
 }
 
 // GetLastMsgWithExternalID returns the most recent visible message on the
 // channel for the contact URN that has a non-empty external_id.
-func GetLastMsgWithExternalID(b *backend, channelID courier.ChannelID, urnIdentity string) (*DBMsg, error) {
-	row := b.db.QueryRowxContext(context.Background(), selectLastMsgWithExternalIDSQL, channelID, urnIdentity)
+func GetLastMsgWithExternalID(ctx context.Context, b *backend, channelID courier.ChannelID, urnIdentity string) (*DBMsg, error) {
+	row := b.db.QueryRowxContext(ctx, selectLastMsgWithExternalIDSQL, channelID, urnIdentity)
 	return scanDBMsgWithMetadata(row)
 }
 

--- a/backends/rapidpro/msg.go
+++ b/backends/rapidpro/msg.go
@@ -2,6 +2,7 @@ package rapidpro
 
 import (
 	"context"
+	"database/sql"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -857,33 +858,82 @@ func GetMsgByUUID(b *backend, uuid string) (*DBMsg, error) {
 // GetMsgByExternalID returns the most recent message on the passed channel
 // with the given external_id, or sql.ErrNoRows when none matches.
 func GetMsgByExternalID(b *backend, channelID courier.ChannelID, externalID string) (*DBMsg, error) {
-	m := &DBMsg{}
-	err := b.db.Get(m, selectMsgByExternalIDSQL, channelID, externalID)
-	if err != nil {
-		return nil, err
-	}
-
-	return m, nil
+	row := b.db.QueryRowxContext(context.Background(), selectMsgByExternalIDSQL, channelID, externalID)
+	return scanDBMsgWithMetadata(row)
 }
 
 // GetMsgByIDWithMetadata returns the message row for the given id including
 // metadata, or sql.ErrNoRows when none matches.
 func GetMsgByIDWithMetadata(b *backend, id courier.MsgID) (*DBMsg, error) {
-	m := &DBMsg{}
-	err := b.db.Get(m, selectMsgByIDWithMetadataSQL, id)
-	if err != nil {
-		return nil, err
-	}
-	return m, nil
+	row := b.db.QueryRowxContext(context.Background(), selectMsgByIDWithMetadataSQL, id)
+	return scanDBMsgWithMetadata(row)
 }
 
 // GetLastMsgWithExternalID returns the most recent visible message on the
 // channel for the contact URN that has a non-empty external_id.
 func GetLastMsgWithExternalID(b *backend, channelID courier.ChannelID, urnIdentity string) (*DBMsg, error) {
+	row := b.db.QueryRowxContext(context.Background(), selectLastMsgWithExternalIDSQL, channelID, urnIdentity)
+	return scanDBMsgWithMetadata(row)
+}
+
+// msgRow is the Scan surface shared by sql.Row / sqlx.Row.
+type msgRow interface {
+	Scan(dest ...interface{}) error
+}
+
+// scanDBMsgWithMetadata scans a msgs_msg row that includes the metadata column.
+//
+// The scan is done manually (rather than via sqlx Get) because the production
+// msgs_msg schema differs from a naive struct mapping in two important ways:
+//   - metadata is "text" rather than jsonb, so the pq driver returns a
+//     string (not []byte) which can't be scanned into *json.RawMessage
+//     directly.
+//   - several columns (high_priority, modified_on, queued_on, sent_on) are
+//     nullable, but the DBMsg fields are plain bool / time.Time, which fail
+//     the scan when the database delivers NULL.
+//
+// Both pitfalls cause db.Get to return an error, which in turn makes the
+// email reply-in-thread lookup degrade silently (parent treated as missing).
+// Reading into nullable holders and copying back keeps the lookup robust to
+// both schemas.
+func scanDBMsgWithMetadata(row msgRow) (*DBMsg, error) {
 	m := &DBMsg{}
-	err := b.db.Get(m, selectLastMsgWithExternalIDSQL, channelID, urnIdentity)
+
+	var (
+		highPriority  sql.NullBool
+		modifiedOn    sql.NullTime
+		queuedOn      sql.NullTime
+		sentOn        sql.NullTime
+		metadataBytes []byte
+	)
+
+	err := row.Scan(
+		&m.ID_, &m.UUID_, &m.OrgID_, &m.Direction_, &m.Text_, &m.Attachments_,
+		&m.MessageCount_, &m.ErrorCount_, &highPriority, &m.Status_, &m.Visibility_,
+		&m.ExternalID_, &m.ChannelID_, &m.ContactID_, &m.ContactURNID_,
+		&m.CreatedOn_, &modifiedOn, &queuedOn, &sentOn,
+		&metadataBytes,
+	)
 	if err != nil {
 		return nil, err
+	}
+
+	if highPriority.Valid {
+		m.HighPriority_ = highPriority.Bool
+	}
+	if modifiedOn.Valid {
+		m.ModifiedOn_ = modifiedOn.Time
+	}
+	if queuedOn.Valid {
+		m.QueuedOn_ = queuedOn.Time
+	}
+	if sentOn.Valid {
+		t := sentOn.Time
+		m.SentOn_ = &t
+	}
+	if len(metadataBytes) > 0 {
+		raw := json.RawMessage(metadataBytes)
+		m.Metadata_ = &raw
 	}
 	return m, nil
 }

--- a/handlers/email/email.go
+++ b/handlers/email/email.go
@@ -3,6 +3,8 @@ package email
 import (
 	"bytes"
 	"context"
+	"crypto/sha1"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -68,7 +70,7 @@ func (h *handler) receiveEvent(ctx context.Context, channel courier.Channel, w h
 		return nil, handlers.WriteAndLogRequestError(ctx, h, channel, w, r, errors.New("field 'body' required"))
 	}
 
-	urn, err := urns.NewURNFromParts(urns.EmailScheme, payload.From, "", "")
+	urn, err := buildContactURN(payload)
 	if err != nil {
 		return nil, handlers.WriteAndLogRequestError(ctx, h, channel, w, r, err)
 	}
@@ -114,6 +116,80 @@ func buildThreadMetadata(payload *moPayload) json.RawMessage {
 		return nil
 	}
 	return body
+}
+
+// threadTagPattern matches the synthetic sub-address tag we inject into the
+// local part of an address to segregate conversations ("+wt-<8 hex chars>"
+// right before the "@"). It is scoped to our own prefix so a real "+" already
+// present in the contact's address (e.g. "person+work@gmail.com") is left
+// untouched.
+var threadTagPattern = regexp.MustCompile(`\+wt-[0-9a-f]{8}(@|$)`)
+
+// buildContactURN derives the URN used to identify the contact for an inbound
+// message. Each new conversation (a message that isn't a reply to anything we
+// recognize) gets its own synthetic address derived from the real one, so
+// Temba creates a distinct contact per subject/thread even though the sender's
+// mailbox is the same. Replies within a thread resolve back to the same
+// synthetic address — and therefore the same contact — because the tag is
+// deterministically derived from the thread's root Message-ID.
+//
+// Messages that carry no threading headers at all (message_id/in_reply_to/
+// references all empty) fall back to the real address, preserving the legacy
+// "one contact per mailbox" behaviour.
+func buildContactURN(payload *moPayload) (urns.URN, error) {
+	address := payload.From
+	if anchor := threadAnchor(payload); anchor != "" {
+		address = withThreadTag(address, anchor)
+	}
+	return urns.NewURNFromParts(urns.EmailScheme, address, "", "")
+}
+
+// threadAnchor returns the Message-ID that identifies the root of the
+// conversation an inbound message belongs to: the oldest entry in References
+// when present (RFC 5322 orders References oldest-first), otherwise
+// In-Reply-To, otherwise the message's own Message-ID — meaning a message
+// with no reply headers anchors a brand new thread. Returns "" when the
+// payload carries no threading information at all.
+func threadAnchor(payload *moPayload) string {
+	if len(payload.References) > 0 {
+		if root := normalizeMessageID(payload.References[0]); root != "" {
+			return root
+		}
+	}
+	if id := normalizeMessageID(payload.InReplyTo); id != "" {
+		return id
+	}
+	if id := normalizeMessageID(payload.MessageID); id != "" {
+		return id
+	}
+	return ""
+}
+
+// withThreadTag inserts a short, deterministic tag derived from the thread
+// anchor into the local part of the address, immediately before the "@".
+func withThreadTag(address, anchor string) string {
+	at := strings.LastIndex(address, "@")
+	if at < 0 {
+		return address
+	}
+	local, domain := address[:at], address[at:]
+	return fmt.Sprintf("%s+wt-%s%s", local, threadHash(anchor), domain)
+}
+
+// threadHash returns a short, stable, URL/email-safe fingerprint of the
+// thread anchor. It doesn't need to be cryptographically strong — only
+// deterministic and low-collision for the same mailbox.
+func threadHash(anchor string) string {
+	sum := sha1.Sum([]byte(anchor))
+	return hex.EncodeToString(sum[:])[:8]
+}
+
+// realAddressFromURNPath strips a thread tag we may have injected into the
+// local part of the contact's URN, returning the actual deliverable mailbox
+// address. Addresses without our tag (legacy contacts, or payloads with no
+// threading info) are returned unchanged.
+func realAddressFromURNPath(path string) string {
+	return threadTagPattern.ReplaceAllString(path, "$1")
 }
 
 // normalizeMessageID trims whitespace and ensures the RFC 5322 angle brackets
@@ -199,7 +275,7 @@ func (h *handler) SendMsg(ctx context.Context, msg courier.Msg) (courier.MsgStat
 	payload := moPayload{
 		UUID:        msg.UUID(),
 		From:        senderEmail,
-		To:          msg.URN().Path(),
+		To:          realAddressFromURNPath(msg.URN().Path()),
 		Subject:     subject,
 		Body:        msg.Text(),
 		Attachments: attachments,

--- a/handlers/email/email.go
+++ b/handlers/email/email.go
@@ -343,11 +343,13 @@ var rePrefixPattern = regexp.MustCompile(`(?i)^\s*re\s*:\s*`)
 // buildReplyContext produces the RFC 5322 threading fields for an outbound
 // reply. When no parent can be resolved it returns empty values and the
 // subject derived from the message body, preserving the legacy "new
-// conversation" behaviour.
+// conversation" behaviour (no "Re:" prefix).
 //
 // When a parent is found, its accumulated References chain and original subject
 // are carried forward — falling back gracefully to a single-entry chain if the
-// parent row can't be loaded from the store.
+// parent row can't be loaded from the store. The "Re:" prefix is only applied
+// when we reuse a parent subject; brand-new sends keep the body-derived subject
+// as-is.
 func (h *handler) buildReplyContext(ctx context.Context, msg courier.Msg) (inReplyTo string, references []string, subject string) {
 	subject = subjectFromMsg(msg)
 	inReplyTo = h.resolveParentExternalID(ctx, msg)
@@ -356,18 +358,20 @@ func (h *handler) buildReplyContext(ctx context.Context, msg courier.Msg) (inRep
 	}
 
 	references = make([]string, 0, 2)
+	reusedParentSubject := false
 	if parent, err := h.Backend().LookupMsgByExternalID(ctx, msg.Channel(), inReplyTo); err == nil && parent != nil {
 		if meta := parseEmailThreadMetadata(parent.Metadata()); meta != nil {
 			references = append(references, meta.References...)
 			if meta.Subject != "" {
 				subject = meta.Subject
+				reusedParentSubject = true
 			}
 		}
 	}
 	references = append(references, inReplyTo)
 	references = normalizeReferences(references)
 
-	if !rePrefixPattern.MatchString(subject) {
+	if reusedParentSubject && !rePrefixPattern.MatchString(subject) {
 		subject = "Re: " + subject
 	}
 	subject = trunkString(subject, 56)

--- a/handlers/email/email.go
+++ b/handlers/email/email.go
@@ -91,14 +91,15 @@ func (h *handler) receiveEvent(ctx context.Context, channel courier.Channel, w h
 }
 
 // buildThreadMetadata returns the email-specific metadata blob to stash on
-// the incoming message, or nil when the payload carries no threading info.
-// The original subject only rides along when threading data is present, since
-// it is exclusively consumed by the outbound "Re:" prefix logic.
+// the incoming message, or nil when the payload carries no email context.
+// Subject is always stored when present so outbound replies can reuse it even
+// when the inbound message is not itself a reply.
 func buildThreadMetadata(payload *moPayload) json.RawMessage {
 	inReplyTo := normalizeMessageID(payload.InReplyTo)
 	references := normalizeReferences(payload.References)
+	subject := strings.TrimSpace(payload.Subject)
 
-	if inReplyTo == "" && len(references) == 0 {
+	if inReplyTo == "" && len(references) == 0 && subject == "" {
 		return nil
 	}
 
@@ -106,7 +107,7 @@ func buildThreadMetadata(payload *moPayload) json.RawMessage {
 		"email": {
 			InReplyTo:  inReplyTo,
 			References: references,
-			Subject:    strings.TrimSpace(payload.Subject),
+			Subject:    subject,
 		},
 	})
 	if err != nil {
@@ -263,16 +264,16 @@ func subjectFromMsg(msg courier.Msg) string {
 var rePrefixPattern = regexp.MustCompile(`(?i)^\s*re\s*:\s*`)
 
 // buildReplyContext produces the RFC 5322 threading fields for an outbound
-// reply. When the message isn't a reply (no ResponseToExternalID set by
-// mailroom) it returns empty values and the original subject derived from the
-// message body, preserving the legacy "new conversation" behaviour.
+// reply. When no parent can be resolved it returns empty values and the
+// subject derived from the message body, preserving the legacy "new
+// conversation" behaviour.
 //
-// When it is a reply, the parent message is loaded so its accumulated
-// References chain and original subject can be carried forward — falling back
-// gracefully to a single-entry chain if the parent can't be resolved.
+// When a parent is found, its accumulated References chain and original subject
+// are carried forward — falling back gracefully to a single-entry chain if the
+// parent row can't be loaded from the store.
 func (h *handler) buildReplyContext(ctx context.Context, msg courier.Msg) (inReplyTo string, references []string, subject string) {
 	subject = subjectFromMsg(msg)
-	inReplyTo = normalizeMessageID(msg.ResponseToExternalID())
+	inReplyTo = h.resolveParentExternalID(ctx, msg)
 	if inReplyTo == "" {
 		return "", nil, subject
 	}
@@ -294,6 +295,33 @@ func (h *handler) buildReplyContext(ctx context.Context, msg courier.Msg) (inRep
 	}
 	subject = trunkString(subject, 56)
 	return inReplyTo, references, subject
+}
+
+// resolveParentExternalID picks the Message-ID of the message being replied to.
+// Mailroom sets response_to_external_id when a flow session is active; when it
+// does not (e.g. ticket/chats without flow), we fall back to response_to_id and
+// then to the latest message on the channel for this contact that has an
+// external_id.
+func (h *handler) resolveParentExternalID(ctx context.Context, msg courier.Msg) string {
+	if id := normalizeMessageID(msg.ResponseToExternalID()); id != "" {
+		return id
+	}
+
+	if msg.ResponseToID() != courier.NilMsgID {
+		if parent, err := h.Backend().LookupMsgByID(ctx, msg.ResponseToID()); err == nil && parent != nil {
+			if id := normalizeMessageID(parent.ExternalID()); id != "" {
+				return id
+			}
+		}
+	}
+
+	if parent, err := h.Backend().LookupLastMsgWithExternalID(ctx, msg.Channel(), msg.URN()); err == nil && parent != nil {
+		if id := normalizeMessageID(parent.ExternalID()); id != "" {
+			return id
+		}
+	}
+
+	return ""
 }
 
 // parseEmailThreadMetadata extracts the email-specific block previously written

--- a/handlers/email/email.go
+++ b/handlers/email/email.go
@@ -17,6 +17,7 @@ import (
 	"github.com/nyaruka/courier/handlers"
 	"github.com/nyaruka/courier/utils"
 	"github.com/nyaruka/gocommon/urns"
+	"github.com/sirupsen/logrus"
 )
 
 var (
@@ -379,24 +380,48 @@ func (h *handler) buildReplyContext(ctx context.Context, msg courier.Msg) (inRep
 // then to the latest message on the channel for this contact that has an
 // external_id.
 func (h *handler) resolveParentExternalID(ctx context.Context, msg courier.Msg) string {
+	log := logrus.WithFields(logrus.Fields{
+		"channel_uuid": msg.Channel().UUID().String(),
+		"msg_id":       msg.ID(),
+		"urn":          msg.URN().Identity(),
+	})
+
 	if id := normalizeMessageID(msg.ResponseToExternalID()); id != "" {
+		log.WithField("in_reply_to", id).WithField("source", "response_to_external_id").
+			Info("resolved parent Message-ID")
 		return id
 	}
 
 	if msg.ResponseToID() != courier.NilMsgID {
-		if parent, err := h.Backend().LookupMsgByID(ctx, msg.ResponseToID()); err == nil && parent != nil {
+		parent, err := h.Backend().LookupMsgByID(ctx, msg.ResponseToID())
+		if err != nil {
+			log.WithError(err).WithField("response_to_id", msg.ResponseToID()).
+				Warn("LookupMsgByID failed while resolving parent")
+		} else if parent != nil {
 			if id := normalizeMessageID(parent.ExternalID()); id != "" {
+				log.WithField("in_reply_to", id).WithField("source", "response_to_id").
+					WithField("response_to_id", msg.ResponseToID()).
+					Info("resolved parent Message-ID")
 				return id
 			}
+			log.WithField("response_to_id", msg.ResponseToID()).
+				Warn("parent found by ResponseToID but has empty external_id")
 		}
 	}
 
-	if parent, err := h.Backend().LookupLastMsgWithExternalID(ctx, msg.Channel(), msg.URN()); err == nil && parent != nil {
+	parent, err := h.Backend().LookupLastMsgWithExternalID(ctx, msg.Channel(), msg.URN())
+	if err != nil {
+		log.WithError(err).Warn("LookupLastMsgWithExternalID failed while resolving parent")
+	} else if parent != nil {
 		if id := normalizeMessageID(parent.ExternalID()); id != "" {
+			log.WithField("in_reply_to", id).WithField("source", "last_msg_for_contact").
+				Info("resolved parent Message-ID")
 			return id
 		}
+		log.Warn("last message for contact has empty external_id")
 	}
 
+	log.Info("no parent Message-ID resolved for outbound reply")
 	return ""
 }
 

--- a/handlers/email/email_test.go
+++ b/handlers/email/email_test.go
@@ -213,7 +213,7 @@ var defaultSendTestCases = []ChannelSendTestCase{
 		Text: "Reply body", URN: "mailto:recipient@example.com",
 		ResponseToExternalID: "<unknown@x>",
 		Status:               "W",
-		RequestBody:          `{"uuid":"00000000-0000-0000-0000-000000000000","from":"test@example.com","to":"recipient@example.com","body":"Reply body","subject":"Re: Reply body","channel_uuid":"8eb23e93-5ecb-45ba-b726-3b064e0c56ab","in_reply_to":"<unknown@x>","references":["<unknown@x>"]}`,
+		RequestBody:          `{"uuid":"00000000-0000-0000-0000-000000000000","from":"test@example.com","to":"recipient@example.com","body":"Reply body","subject":"Reply body","channel_uuid":"8eb23e93-5ecb-45ba-b726-3b064e0c56ab","in_reply_to":"<unknown@x>","references":["<unknown@x>"]}`,
 		ResponseBody:         `{"status":"sent"}`, ResponseStatus: 200,
 		SendPrep: setSendURL},
 

--- a/handlers/email/email_test.go
+++ b/handlers/email/email_test.go
@@ -39,12 +39,22 @@ var (
 var receiveTestCases = []ChannelHandleTestCase{
 	{Label: "Receive plain without threading",
 		URL: receiveURL, Data: plainReceive, Status: 200, Response: "Message Accepted",
-		Text: Sp("Hi there"), URN: Sp("mailto:client@example.com"), ExternalID: Sp("")},
+		Text: Sp("Hi there"), URN: Sp("mailto:client@example.com"), ExternalID: Sp(""),
+		Metadata: Jp(map[string]interface{}{
+			"email": map[string]interface{}{
+				"subject": "Hello",
+			},
+		})},
 
 	{Label: "Receive with message_id only",
 		URL: receiveURL, Data: messageIDOnly, Status: 200, Response: "Message Accepted",
 		Text: Sp("First message"), URN: Sp("mailto:client@example.com"),
-		ExternalID: Sp("<first@example.com>")},
+		ExternalID: Sp("<first@example.com>"),
+		Metadata: Jp(map[string]interface{}{
+			"email": map[string]interface{}{
+				"subject": "Hi",
+			},
+		})},
 
 	{Label: "Receive with full threading",
 		URL: receiveURL, Data: threadedReceive, Status: 200, Response: "Message Accepted",
@@ -193,6 +203,21 @@ var defaultSendTestCases = []ChannelSendTestCase{
 		RequestBody:          `{"uuid":"00000000-0000-0000-0000-000000000000","from":"test@example.com","to":"client@example.com","body":"Body","subject":"Re: Pedido #123","channel_uuid":"8eb23e93-5ecb-45ba-b726-3b064e0c56ab","in_reply_to":"<root@x>","references":["<root@x>"]}`,
 		ResponseBody:         `{"status":"sent"}`, ResponseStatus: 200,
 		SendPrep: setSendURL},
+
+	{Label: "Send reply via ResponseToID when ResponseToExternalID empty",
+		Text: "Reply body", URN: "mailto:client@example.com",
+		ResponseToID: 42,
+		Status:       "W",
+		RequestBody:  `{"uuid":"00000000-0000-0000-0000-000000000000","from":"test@example.com","to":"client@example.com","body":"Reply body","subject":"Re: Via ID","channel_uuid":"8eb23e93-5ecb-45ba-b726-3b064e0c56ab","in_reply_to":"<via-id@x>","references":["<via-id@x>"]}`,
+		ResponseBody: `{"status":"sent"}`, ResponseStatus: 200,
+		SendPrep: setSendURL},
+
+	{Label: "Send reply via last contact message when no mailroom parent",
+		Text: "Agent reply", URN: "mailto:ticket@example.com",
+		Status:       "W",
+		RequestBody:  `{"uuid":"00000000-0000-0000-0000-000000000000","from":"test@example.com","to":"ticket@example.com","body":"Agent reply","subject":"Re: Account issue","channel_uuid":"8eb23e93-5ecb-45ba-b726-3b064e0c56ab","in_reply_to":"<ticket-inbound@x>","references":["<ticket-inbound@x>"]}`,
+		ResponseBody: `{"status":"sent"}`, ResponseStatus: 200,
+		SendPrep: setSendURL},
 }
 
 // seedParents pre-populates the mock backend with parent inbound messages so
@@ -212,6 +237,19 @@ func seedParents(mb *courier.MockBackend) {
 		WithExternalID("<existingre@x>").
 		WithMetadata(json.RawMessage(`{"email":{"references":["<r@x>"],"subject":"Re: Already prefixed"}}`))
 	mb.AddMsgByExternalID(parent3)
+
+	parentViaID := mb.NewIncomingMsg(defaultChannel, urns.URN("mailto:client@example.com"), "Via ID").
+		WithID(courier.NewMsgID(42)).
+		WithExternalID("<via-id@x>").
+		WithMetadata(json.RawMessage(`{"email":{"subject":"Via ID"}}`))
+	mb.AddMsgByID(parentViaID)
+	mb.AddMsgByExternalID(parentViaID)
+
+	lastInbound := mb.NewIncomingMsg(defaultChannel, urns.URN("mailto:ticket@example.com"), "Help").
+		WithExternalID("<ticket-inbound@x>").
+		WithMetadata(json.RawMessage(`{"email":{"subject":"Account issue"}}`))
+	mb.AddLastMsgForContact(lastInbound)
+	mb.AddMsgByExternalID(lastInbound)
 }
 
 func TestSending(t *testing.T) {

--- a/handlers/email/email_test.go
+++ b/handlers/email/email_test.go
@@ -34,7 +34,21 @@ var (
 	emptyReferences = `{"from":"client@example.com","to":"support@company.com","subject":"Re:","body":"resp","channel_uuid":"8eb23e93-5ecb-45ba-b726-3b064e0c56ab","message_id":"<a@x>","in_reply_to":"<b@x>","references":[]}`
 	missingFrom     = `{"to":"support@company.com","body":"hi","channel_uuid":"8eb23e93-5ecb-45ba-b726-3b064e0c56ab"}`
 	missingBody     = `{"from":"client@example.com","to":"support@company.com","channel_uuid":"8eb23e93-5ecb-45ba-b726-3b064e0c56ab"}`
+
+	// Two brand new (non-reply) messages from the same mailbox on different
+	// subjects should become two distinct contacts, while a reply to the
+	// first one should resolve back to that same contact.
+	newThreadProduct = `{"from":"fulano123@gmail.com","to":"support@company.com","subject":"Meu Produto","body":"Duvida sobre produto","channel_uuid":"8eb23e93-5ecb-45ba-b726-3b064e0c56ab","message_id":"<produto@example.com>"}`
+	newThreadInvoice = `{"from":"fulano123@gmail.com","to":"support@company.com","subject":"Minha fatura","body":"Duvida sobre fatura","channel_uuid":"8eb23e93-5ecb-45ba-b726-3b064e0c56ab","message_id":"<fatura@example.com>"}`
+	replyToProduct   = `{"from":"fulano123@gmail.com","to":"support@company.com","subject":"Re: Meu Produto","body":"Resposta produto","channel_uuid":"8eb23e93-5ecb-45ba-b726-3b064e0c56ab","message_id":"<produto-reply@example.com>","in_reply_to":"<agent-produto@ourdomain.com>","references":["<produto@example.com>","<agent-produto@ourdomain.com>"]}`
 )
+
+// urnWithTag builds the "mailto:" URN we expect the handler to derive for an
+// address anchored to the given (unnormalized) Message-ID, mirroring the
+// production per-thread contact segregation logic.
+func urnWithTag(address, anchor string) string {
+	return "mailto:" + withThreadTag(address, normalizeMessageID(anchor))
+}
 
 var receiveTestCases = []ChannelHandleTestCase{
 	{Label: "Receive plain without threading",
@@ -48,7 +62,7 @@ var receiveTestCases = []ChannelHandleTestCase{
 
 	{Label: "Receive with message_id only",
 		URL: receiveURL, Data: messageIDOnly, Status: 200, Response: "Message Accepted",
-		Text: Sp("First message"), URN: Sp("mailto:client@example.com"),
+		Text: Sp("First message"), URN: Sp(urnWithTag("client@example.com", "<first@example.com>")),
 		ExternalID: Sp("<first@example.com>"),
 		Metadata: Jp(map[string]interface{}{
 			"email": map[string]interface{}{
@@ -58,7 +72,7 @@ var receiveTestCases = []ChannelHandleTestCase{
 
 	{Label: "Receive with full threading",
 		URL: receiveURL, Data: threadedReceive, Status: 200, Response: "Message Accepted",
-		Text: Sp("Resposta"), URN: Sp("mailto:client@example.com"),
+		Text: Sp("Resposta"), URN: Sp(urnWithTag("client@example.com", "<root@example.com>")),
 		ExternalID: Sp("<CABc@mail.gmail.com>"),
 		Metadata: Jp(map[string]interface{}{
 			"email": map[string]interface{}{
@@ -70,7 +84,7 @@ var receiveTestCases = []ChannelHandleTestCase{
 
 	{Label: "Receive normalizes missing angle brackets",
 		URL: receiveURL, Data: missingBrackets, Status: 200, Response: "Message Accepted",
-		Text: Sp("resp"), URN: Sp("mailto:client@example.com"),
+		Text: Sp("resp"), URN: Sp(urnWithTag("client@example.com", "root@example.com")),
 		ExternalID: Sp("<abc@example.com>"),
 		Metadata: Jp(map[string]interface{}{
 			"email": map[string]interface{}{
@@ -82,7 +96,7 @@ var receiveTestCases = []ChannelHandleTestCase{
 
 	{Label: "Receive dedupes references",
 		URL: receiveURL, Data: dupReferences, Status: 200, Response: "Message Accepted",
-		Text: Sp("resp"), URN: Sp("mailto:client@example.com"),
+		Text: Sp("resp"), URN: Sp(urnWithTag("client@example.com", "<root@x>")),
 		ExternalID: Sp("<a@x>"),
 		Metadata: Jp(map[string]interface{}{
 			"email": map[string]interface{}{
@@ -94,7 +108,7 @@ var receiveTestCases = []ChannelHandleTestCase{
 
 	{Label: "Receive accepts null references",
 		URL: receiveURL, Data: nullReferences, Status: 200, Response: "Message Accepted",
-		Text: Sp("resp"), URN: Sp("mailto:client@example.com"),
+		Text: Sp("resp"), URN: Sp(urnWithTag("client@example.com", "<b@x>")),
 		ExternalID: Sp("<a@x>"),
 		Metadata: Jp(map[string]interface{}{
 			"email": map[string]interface{}{
@@ -105,7 +119,7 @@ var receiveTestCases = []ChannelHandleTestCase{
 
 	{Label: "Receive accepts empty references",
 		URL: receiveURL, Data: emptyReferences, Status: 200, Response: "Message Accepted",
-		Text: Sp("resp"), URN: Sp("mailto:client@example.com"),
+		Text: Sp("resp"), URN: Sp(urnWithTag("client@example.com", "<b@x>")),
 		ExternalID: Sp("<a@x>"),
 		Metadata: Jp(map[string]interface{}{
 			"email": map[string]interface{}{
@@ -116,6 +130,37 @@ var receiveTestCases = []ChannelHandleTestCase{
 
 	{Label: "Missing from", URL: receiveURL, Data: missingFrom, Status: 400, Response: "'from' required"},
 	{Label: "Missing body", URL: receiveURL, Data: missingBody, Status: 400, Response: "'body' required"},
+
+	{Label: "New thread on subject Meu Produto gets its own contact",
+		URL: receiveURL, Data: newThreadProduct, Status: 200, Response: "Message Accepted",
+		Text: Sp("Duvida sobre produto"), URN: Sp(urnWithTag("fulano123@gmail.com", "<produto@example.com>")),
+		ExternalID: Sp("<produto@example.com>")},
+
+	{Label: "New thread on subject Minha fatura gets a different contact",
+		URL: receiveURL, Data: newThreadInvoice, Status: 200, Response: "Message Accepted",
+		Text: Sp("Duvida sobre fatura"), URN: Sp(urnWithTag("fulano123@gmail.com", "<fatura@example.com>")),
+		ExternalID: Sp("<fatura@example.com>")},
+
+	{Label: "Reply to Meu Produto thread resolves back to that same contact",
+		URL: receiveURL, Data: replyToProduct, Status: 200, Response: "Message Accepted",
+		Text: Sp("Resposta produto"), URN: Sp(urnWithTag("fulano123@gmail.com", "<produto@example.com>")),
+		ExternalID: Sp("<produto-reply@example.com>")},
+}
+
+// TestThreadContactSegregation asserts that the URN derived for a reply to a
+// thread matches the URN derived for that thread's originating message, while
+// two independent new threads from the same mailbox get different URNs.
+func TestThreadContactSegregation(t *testing.T) {
+	productURN := urnWithTag("fulano123@gmail.com", "<produto@example.com>")
+	invoiceURN := urnWithTag("fulano123@gmail.com", "<fatura@example.com>")
+	replyURN := urnWithTag("fulano123@gmail.com", "<produto@example.com>")
+
+	if productURN == invoiceURN {
+		t.Fatalf("expected different subjects to derive different contact URNs, both got %q", productURN)
+	}
+	if productURN != replyURN {
+		t.Fatalf("expected a reply to the original thread to derive the same contact URN: got %q, want %q", replyURN, productURN)
+	}
 }
 
 func TestHandler(t *testing.T) {
@@ -216,6 +261,20 @@ var defaultSendTestCases = []ChannelSendTestCase{
 		Text: "Agent reply", URN: "mailto:ticket@example.com",
 		Status:       "W",
 		RequestBody:  `{"uuid":"00000000-0000-0000-0000-000000000000","from":"test@example.com","to":"ticket@example.com","body":"Agent reply","subject":"Re: Account issue","channel_uuid":"8eb23e93-5ecb-45ba-b726-3b064e0c56ab","in_reply_to":"<ticket-inbound@x>","references":["<ticket-inbound@x>"]}`,
+		ResponseBody: `{"status":"sent"}`, ResponseStatus: 200,
+		SendPrep: setSendURL},
+
+	{Label: "Send strips synthetic thread tag before delivering to the real mailbox",
+		Text: "Reply body", URN: "mailto:fulano123+wt-deadbeef@gmail.com",
+		Status:       "W",
+		RequestBody:  `{"uuid":"00000000-0000-0000-0000-000000000000","from":"test@example.com","to":"fulano123@gmail.com","body":"Reply body","subject":"Reply body","channel_uuid":"8eb23e93-5ecb-45ba-b726-3b064e0c56ab"}`,
+		ResponseBody: `{"status":"sent"}`, ResponseStatus: 200,
+		SendPrep: setSendURL},
+
+	{Label: "Send preserves a real plus alias unrelated to our thread tag",
+		Text: "Reply body", URN: "mailto:person+work@gmail.com",
+		Status:       "W",
+		RequestBody:  `{"uuid":"00000000-0000-0000-0000-000000000000","from":"test@example.com","to":"person+work@gmail.com","body":"Reply body","subject":"Reply body","channel_uuid":"8eb23e93-5ecb-45ba-b726-3b064e0c56ab"}`,
 		ResponseBody: `{"status":"sent"}`, ResponseStatus: 200,
 		SendPrep: setSendURL},
 }

--- a/test.go
+++ b/test.go
@@ -56,6 +56,13 @@ type MockBackend struct {
 	// msgsByExternalID is seeded by tests to back LookupMsgByExternalID; keyed
 	// as "<channelUUID>|<externalID>".
 	msgsByExternalID map[string]Msg
+
+	// msgsByID is seeded by tests to back LookupMsgByID.
+	msgsByID map[MsgID]Msg
+
+	// lastMsgByChannelURN is seeded by tests to back LookupLastMsgWithExternalID;
+	// keyed as "<channelUUID>|<urnIdentity>".
+	lastMsgByChannelURN map[string]Msg
 }
 
 // NewMockBackend returns a new mock backend suitable for testing
@@ -83,12 +90,14 @@ func NewMockBackend() *MockBackend {
 	}
 
 	return &MockBackend{
-		channels:          make(map[ChannelUUID]Channel),
-		channelsByAddress: make(map[ChannelAddress]Channel),
-		contacts:          make(map[urns.URN]Contact),
-		sentMsgs:          make(map[MsgID]bool),
-		redisPool:         redisPool,
-		msgsByExternalID:  make(map[string]Msg),
+		channels:            make(map[ChannelUUID]Channel),
+		channelsByAddress:   make(map[ChannelAddress]Channel),
+		contacts:            make(map[urns.URN]Contact),
+		sentMsgs:            make(map[MsgID]bool),
+		redisPool:           redisPool,
+		msgsByExternalID:    make(map[string]Msg),
+		msgsByID:            make(map[MsgID]Msg),
+		lastMsgByChannelURN: make(map[string]Msg),
 	}
 }
 
@@ -102,6 +111,27 @@ func (mb *MockBackend) AddMsgByExternalID(msg Msg) {
 	}
 	key := fmt.Sprintf("%s|%s", msg.Channel().UUID(), msg.ExternalID())
 	mb.msgsByExternalID[key] = msg
+}
+
+// AddMsgByID seeds a parent message keyed by its Temba id.
+func (mb *MockBackend) AddMsgByID(msg Msg) {
+	mb.mutex.Lock()
+	defer mb.mutex.Unlock()
+	if msg == nil || msg.ID() == NilMsgID {
+		return
+	}
+	mb.msgsByID[msg.ID()] = msg
+}
+
+// AddLastMsgForContact seeds the latest message for a channel + contact URN pair.
+func (mb *MockBackend) AddLastMsgForContact(msg Msg) {
+	mb.mutex.Lock()
+	defer mb.mutex.Unlock()
+	if msg == nil || msg.Channel() == nil || msg.URN() == urns.NilURN || msg.ExternalID() == "" {
+		return
+	}
+	key := fmt.Sprintf("%s|%s", msg.Channel().UUID(), msg.URN().Identity())
+	mb.lastMsgByChannelURN[key] = msg
 }
 
 // GetLastQueueMsg returns the last message queued to the server
@@ -456,6 +486,33 @@ func (b *MockBackend) LookupMsgByExternalID(ctx context.Context, channel Channel
 	key := fmt.Sprintf("%s|%s", channel.UUID(), externalID)
 	msg, ok := b.msgsByExternalID[key]
 	if !ok {
+		return nil, ErrMsgNotFound
+	}
+	return msg, nil
+}
+
+func (b *MockBackend) LookupMsgByID(ctx context.Context, id MsgID) (Msg, error) {
+	if id == NilMsgID {
+		return nil, ErrMsgNotFound
+	}
+	b.mutex.RLock()
+	defer b.mutex.RUnlock()
+	msg, ok := b.msgsByID[id]
+	if !ok {
+		return nil, ErrMsgNotFound
+	}
+	return msg, nil
+}
+
+func (b *MockBackend) LookupLastMsgWithExternalID(ctx context.Context, channel Channel, urn urns.URN) (Msg, error) {
+	if channel == nil || urn == urns.NilURN {
+		return nil, ErrMsgNotFound
+	}
+	b.mutex.RLock()
+	defer b.mutex.RUnlock()
+	key := fmt.Sprintf("%s|%s", channel.UUID(), urn.Identity())
+	msg, ok := b.lastMsgByChannelURN[key]
+	if !ok || msg.ExternalID() == "" {
 		return nil, ErrMsgNotFound
 	}
 	return msg, nil


### PR DESCRIPTION
Summary

Replies now resolve correctly even without an active flow session, via a fallback chain: response_to_external_id → response_to_id → last contact message with external_id.
Each new email thread (by root Message-ID) creates a distinct Temba contact, using a tagged synthetic address (local+wt-<hash>@domain); replies resolve back to the original contact. The tag is stripped before SMTP delivery, so the real mailbox is always used.
New Backend methods: LookupMsgByID, LookupLastMsgWithExternalID (RapidPro impl + mock).