### PR TITLE
fix: publish WAMID return events for AB2 projects

### DIFF
--- a/WENI-CHANGELOG.md
+++ b/WENI-CHANGELOG.md
@@ -1,3 +1,7 @@
+1.59.2
+----------
+ * fix: publish whatsapp-cloud-token (WAMID return) for AB2/is_multi_agents projects so agent messages get external_id in chats-engine; keep billing create suppressed for AB2
+
 1.59.1
 ----------
  * fix: Update WhatsApp message handling to improve URN assignment logic

--- a/sender.go
+++ b/sender.go
@@ -283,43 +283,9 @@ func (w *Sender) sendMessage(msg Msg) {
 		sentOk := status.Status() != MsgErrored && status.Status() != MsgFailed
 		isMultiAgentsConf := msg.Channel().OrgConfigForKey("is_multi_agents", false)
 		isMultiAgents, _ := isMultiAgentsConf.(bool)
-		billingPublishOk := sentOk && !isMultiAgents
 		isTemplateMessage, metadata := isTemplateMessage(msg)
 
-		if billingPublishOk {
-			if w.foreman.server.Billing() != nil {
-				chatsUUID, _ := jsonparser.GetString(msg.Metadata(), "chats_msg_uuid")
-				ticketerType, _ := jsonparser.GetString(msg.Metadata(), "ticketer_type")
-				fromTicketer := ticketerType != ""
-
-				billingMsg := billing.NewMessage(
-					string(msg.URN().Identity()),
-					"",
-					msg.ContactName(),
-					msg.Channel().UUID().String(),
-					status.ExternalID(),
-					time.Now().Format(time.RFC3339),
-					"O",
-					msg.Channel().ChannelType().String(),
-					msg.Text(),
-					msg.Attachments(),
-					msg.QuickReplies(),
-					fromTicketer,
-					chatsUUID,
-					string(msg.Status()),
-					msg.BroadcastID(),
-				)
-
-				if isTemplateMessage {
-					billingMsg.TemplateUUID = metadata.Templating.Template.UUID
-				}
-
-				if msg.Channel().ChannelType() == "WAC" {
-					w.foreman.server.Billing().SendAsync(billingMsg, billing.RoutingKeyWAC, nil, nil)
-				}
-				w.foreman.server.Billing().SendAsync(billingMsg, billing.RoutingKeyCreate, nil, nil)
-			}
-		}
+		publishOutgoingMsgEvents(w.foreman.server.Billing(), msg, status, sentOk, isMultiAgents, isTemplateMessage, metadata)
 
 		if w.foreman.server.Templates() != nil && isTemplateMessage {
 			templatingData := metadata.Templating
@@ -370,6 +336,64 @@ func (w *Sender) sendMessage(msg Msg) {
 
 	// mark our send task as complete
 	backend.MarkOutgoingMsgComplete(writeCTX, msg, status)
+}
+
+// publishOutgoingMsgEvents publishes post-send events for chats-engine and billing.
+//
+// RoutingKeyWAC (whatsapp-cloud-token) carries the Meta WAMID back to chats-engine so
+// agent messages get their external_id set (required for reply indexing). It must be
+// published for every successful WAC send, including AB2 (is_multi_agents) projects.
+//
+// RoutingKeyCreate is the billing create event and remains suppressed for AB2 projects
+// (Courier v1.50.1 behaviour).
+func publishOutgoingMsgEvents(
+	client billing.Client,
+	msg Msg,
+	status MsgStatus,
+	sentOk bool,
+	isMultiAgents bool,
+	isTemplateMessage bool,
+	templateMetadata *templates.TemplateMetadata,
+) {
+	if !sentOk || client == nil {
+		return
+	}
+
+	chatsUUID, _ := jsonparser.GetString(msg.Metadata(), "chats_msg_uuid")
+	ticketerType, _ := jsonparser.GetString(msg.Metadata(), "ticketer_type")
+	fromTicketer := ticketerType != ""
+
+	billingMsg := billing.NewMessage(
+		string(msg.URN().Identity()),
+		"",
+		msg.ContactName(),
+		msg.Channel().UUID().String(),
+		status.ExternalID(),
+		time.Now().Format(time.RFC3339),
+		"O",
+		msg.Channel().ChannelType().String(),
+		msg.Text(),
+		msg.Attachments(),
+		msg.QuickReplies(),
+		fromTicketer,
+		chatsUUID,
+		string(msg.Status()),
+		msg.BroadcastID(),
+	)
+
+	if isTemplateMessage && templateMetadata != nil && templateMetadata.Templating != nil {
+		billingMsg.TemplateUUID = templateMetadata.Templating.Template.UUID
+	}
+
+	// Always return WAMID to chats-engine for successful WAC sends (including AB2).
+	if msg.Channel().ChannelType() == "WAC" {
+		client.SendAsync(billingMsg, billing.RoutingKeyWAC, nil, nil)
+	}
+
+	// Billing create stays suppressed for AB2 (is_multi_agents) projects.
+	if !isMultiAgents {
+		client.SendAsync(billingMsg, billing.RoutingKeyCreate, nil, nil)
+	}
 }
 
 // isTemplateMessage checks if a message contains valid template metadata

--- a/sender_msg_events_test.go
+++ b/sender_msg_events_test.go
@@ -1,0 +1,126 @@
+package courier
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/nyaruka/courier/billing"
+	"github.com/nyaruka/gocommon/urns"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// recordingMsgEventsClient records every SendAsync call (routing key + payload).
+type recordingMsgEventsClient struct {
+	calls []struct {
+		routingKey string
+		msg        billing.Message
+	}
+}
+
+func (c *recordingMsgEventsClient) Send(msg billing.Message, routingKey string) error {
+	c.calls = append(c.calls, struct {
+		routingKey string
+		msg        billing.Message
+	}{routingKey: routingKey, msg: msg})
+	return nil
+}
+
+func (c *recordingMsgEventsClient) SendAsync(msg billing.Message, routingKey string, pre func(), post func()) {
+	if pre != nil {
+		pre()
+	}
+	_ = c.Send(msg, routingKey)
+	if post != nil {
+		post()
+	}
+}
+
+func (c *recordingMsgEventsClient) routingKeys() []string {
+	keys := make([]string, len(c.calls))
+	for i, call := range c.calls {
+		keys[i] = call.routingKey
+	}
+	return keys
+}
+
+func newTestOutgoingMsg(channelType string, metadata map[string]interface{}) (Msg, MsgStatus) {
+	channel := NewMockChannel("8eb23e93-5ecb-45ba-b726-3b064e0c56ab", channelType, "12345", "BR", map[string]interface{}{})
+	msg := &mockMsg{
+		channel:     channel,
+		id:          NewMsgID(10),
+		text:        "hello from agent",
+		urn:         urns.URN("whatsapp:5511999999999"),
+		contactName: "Contact",
+	}
+	if metadata != nil {
+		raw, _ := json.Marshal(metadata)
+		msg.metadata = raw
+	}
+
+	status := &mockMsgStatus{
+		channel:    channel,
+		id:         msg.id,
+		status:     MsgWired,
+		externalID: "wamid.HBgNNTUxMTk5OTk5OTk5ORUCABIYFjNBMDJCOTk5OTk5OTk5OTk5OTk5AA==",
+	}
+	return msg, status
+}
+
+func TestPublishOutgoingMsgEvents_AB2StillPublishesWAC(t *testing.T) {
+	client := &recordingMsgEventsClient{}
+	msg, status := newTestOutgoingMsg("WAC", map[string]interface{}{
+		"chats_msg_uuid": "68f2c4c7-fa2a-40a6-b518-3b609a0bd413",
+	})
+
+	publishOutgoingMsgEvents(client, msg, status, true, true, false, nil)
+
+	require.Len(t, client.calls, 1, "AB2 must still publish WAMID return event")
+	assert.Equal(t, billing.RoutingKeyWAC, client.calls[0].routingKey)
+	assert.Equal(t, "68f2c4c7-fa2a-40a6-b518-3b609a0bd413", client.calls[0].msg.ChatsUUID)
+	assert.Equal(t, status.ExternalID(), client.calls[0].msg.MessageID)
+	assert.NotContains(t, client.routingKeys(), billing.RoutingKeyCreate, "billing create must stay suppressed for AB2")
+}
+
+func TestPublishOutgoingMsgEvents_AB1PublishesWACAndCreate(t *testing.T) {
+	client := &recordingMsgEventsClient{}
+	msg, status := newTestOutgoingMsg("WAC", map[string]interface{}{
+		"chats_msg_uuid": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+	})
+
+	publishOutgoingMsgEvents(client, msg, status, true, false, false, nil)
+
+	assert.Equal(t, []string{billing.RoutingKeyWAC, billing.RoutingKeyCreate}, client.routingKeys())
+	assert.Equal(t, "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee", client.calls[0].msg.ChatsUUID)
+	assert.Equal(t, status.ExternalID(), client.calls[0].msg.MessageID)
+}
+
+func TestPublishOutgoingMsgEvents_NonWACSkipsWACKey(t *testing.T) {
+	client := &recordingMsgEventsClient{}
+	msg, status := newTestOutgoingMsg("WA", map[string]interface{}{
+		"chats_msg_uuid": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+	})
+
+	publishOutgoingMsgEvents(client, msg, status, true, false, false, nil)
+
+	assert.Equal(t, []string{billing.RoutingKeyCreate}, client.routingKeys())
+}
+
+func TestPublishOutgoingMsgEvents_FailedSendPublishesNothing(t *testing.T) {
+	client := &recordingMsgEventsClient{}
+	msg, status := newTestOutgoingMsg("WAC", map[string]interface{}{
+		"chats_msg_uuid": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+	})
+	status.SetStatus(MsgFailed)
+
+	publishOutgoingMsgEvents(client, msg, status, false, false, false, nil)
+
+	assert.Empty(t, client.calls)
+}
+
+func TestPublishOutgoingMsgEvents_NilClientIsNoop(t *testing.T) {
+	msg, status := newTestOutgoingMsg("WAC", nil)
+	assert.NotPanics(t, func() {
+		publishOutgoingMsgEvents(nil, msg, status, true, false, false, nil)
+	})
+}


### PR DESCRIPTION
## What
- Decouples the WAMID return path (`whatsapp-cloud-token`) from the AB2 billing gate in Courier's sender.
- Successful WAC sends now publish the WAMID event even when `is_multi_agents` is true, so chats-engine can set `external_id` on agent messages.
- Keeps billing `create` suppressed for AB2 projects (unchanged v1.50.1 behaviour).
- Extracts `publishOutgoingMsgEvents` and adds unit coverage for AB2/AB1/non-WAC/failed/nil-client cases.
- Changelog: `1.59.2`.

## Why
On AB2 projects (e.g. Oxford, `is_multi_agents: true`), agent messages reached WhatsApp and appeared in chats, but never got a WAMID back into chats-engine. That broke reply mounting when contacts replied to those messages.

Root cause: since Courier v1.50.1, `billingPublishOk := sentOk && !isMultiAgents` gated both billing create and the WAMID return event. AB2 intentionally skips billing, but the WAMID return is required for reply indexing and was incorrectly skipped with it.

## Test plan
- [ ] Unit tests: `go test ./ -run TestPublishOutgoingMsgEvents`
- [ ] On an AB2 project (`is_multi_agents: true`), send an agent message via WAC
- [ ] Confirm Courier logs publish with `routing_key: whatsapp-cloud-token`
- [ ] Confirm chats-engine `MsgConsumer` sets `external_id` on the message
- [ ] Confirm contact replies to that agent message mount correctly
- [ ] Confirm AB2 still does **not** publish billing `create`
- [ ] Confirm AB1 still publishes both `whatsapp-cloud-token` and `create`


Made with [Cursor](https://cursor.com)