### PR TITLE
feat: persist email thread metadata on outbound sends Subsequent replies were starting new threads because the parent outbound had no metadata.email for subject/References reuse.

### DIFF
--- a/backends/rapidpro/status.go
+++ b/backends/rapidpro/status.go
@@ -123,6 +123,14 @@ UPDATE msgs_msg SET
 		ELSE
 			external_id
 		END,
+	metadata = CASE
+		WHEN
+			CAST(:metadata AS text) IS NOT NULL AND CAST(:metadata AS text) != ''
+		THEN
+			:metadata
+		ELSE
+			metadata
+		END,
 	modified_on = :modified_on
 WHERE 
 	msgs_msg.id = :msg_id AND
@@ -291,11 +299,19 @@ UPDATE msgs_msg SET
 		ELSE
 			msgs_msg.external_id
 		END,
+	metadata = CASE
+		WHEN
+			s.metadata IS NOT NULL AND s.metadata != ''
+		THEN
+			s.metadata
+		ELSE
+			msgs_msg.metadata
+		END,
 	modified_on = NOW()
 FROM
-	(VALUES(:msg_id, :channel_id, :status, :external_id)) 
+	(VALUES(:msg_id, :channel_id, :status, :external_id, :metadata)) 
 AS 
-	s(msg_id, channel_id, status, external_id) 
+	s(msg_id, channel_id, status, external_id, metadata) 
 WHERE 
 	msgs_msg.id = s.msg_id::bigint AND
 	msgs_msg.channel_id = s.channel_id::int AND 
@@ -374,3 +390,10 @@ func (s *DBMsgStatus) Status() courier.MsgStatusValue          { return s.Status
 func (s *DBMsgStatus) SetStatus(status courier.MsgStatusValue) { s.Status_ = status }
 
 func (s *DBMsgStatus) Metadata() json.RawMessage { return s.Metadata_ }
+func (s *DBMsgStatus) SetMetadata(m json.RawMessage) {
+	if len(m) == 0 {
+		s.Metadata_ = nil
+		return
+	}
+	s.Metadata_ = m
+}

--- a/handlers/email/email.go
+++ b/handlers/email/email.go
@@ -314,6 +314,16 @@ func (h *handler) SendMsg(ctx context.Context, msg courier.Msg) (courier.MsgStat
 				status.SetExternalID(normalized)
 			}
 		}
+
+		// stash the thread context we just sent on this outbound message so a
+		// subsequent send that resolves us as parent can reuse subject and
+		// extend References — without this, the next turn falls back to the
+		// body-derived subject and starts a new thread in most clients
+		if emailMeta := buildOutboundThreadMetadata(inReplyTo, references, subject); emailMeta != nil {
+			if merged := mergeEmailMetadata(msg.Metadata(), emailMeta); merged != nil {
+				status.SetMetadata(merged)
+			}
+		}
 	}
 	status.AddLog(log)
 	return status, nil
@@ -443,4 +453,66 @@ func parseEmailThreadMetadata(raw json.RawMessage) *emailThreadMetadata {
 		return nil
 	}
 	return wrapper.Email
+}
+
+// buildOutboundThreadMetadata returns the email-specific metadata blob to stash
+// on an outbound message after a successful send, mirroring what
+// buildThreadMetadata writes for inbound. Subject is always stored when present
+// so a subsequent outbound that resolves this message as parent can reuse it
+// even when this send was not itself a reply.
+func buildOutboundThreadMetadata(inReplyTo string, references []string, subject string) json.RawMessage {
+	inReplyTo = normalizeMessageID(inReplyTo)
+	references = normalizeReferences(references)
+	subject = strings.TrimSpace(subject)
+
+	if inReplyTo == "" && len(references) == 0 && subject == "" {
+		return nil
+	}
+
+	body, err := json.Marshal(map[string]emailThreadMetadata{
+		"email": {
+			InReplyTo:  inReplyTo,
+			References: references,
+			Subject:    subject,
+		},
+	})
+	if err != nil {
+		return nil
+	}
+	return body
+}
+
+// mergeEmailMetadata merges the email thread block from emailBlock into the
+// existing message metadata, preserving unrelated keys (ticketer_id,
+// chats_msg_uuid, etc.). Returns nil when emailBlock is empty.
+func mergeEmailMetadata(existing, emailBlock json.RawMessage) json.RawMessage {
+	if len(emailBlock) == 0 {
+		return nil
+	}
+
+	var emailWrapper struct {
+		Email json.RawMessage `json:"email"`
+	}
+	if err := json.Unmarshal(emailBlock, &emailWrapper); err != nil || len(emailWrapper.Email) == 0 {
+		return nil
+	}
+
+	merged := map[string]interface{}{}
+	if len(existing) > 0 {
+		if err := json.Unmarshal(existing, &merged); err != nil {
+			// existing isn't a JSON object; fall back to the email block alone
+			return emailBlock
+		}
+	}
+	var emailValue interface{}
+	if err := json.Unmarshal(emailWrapper.Email, &emailValue); err != nil {
+		return nil
+	}
+	merged["email"] = emailValue
+
+	out, err := json.Marshal(merged)
+	if err != nil {
+		return emailBlock
+	}
+	return out
 }

--- a/handlers/email/email.go
+++ b/handlers/email/email.go
@@ -76,7 +76,7 @@ func (h *handler) receiveEvent(ctx context.Context, channel courier.Channel, w h
 		return nil, handlers.WriteAndLogRequestError(ctx, h, channel, w, r, err)
 	}
 
-	msg := h.Backend().NewIncomingMsg(channel, urn, payload.Body)
+	msg := h.Backend().NewIncomingMsg(channel, urn, payload.Body).WithContactName(payload.From)
 
 	for _, attachment := range payload.Attachments {
 		msg.WithAttachment(attachment)

--- a/handlers/email/email.go
+++ b/handlers/email/email.go
@@ -482,35 +482,28 @@ func buildOutboundThreadMetadata(inReplyTo string, references []string, subject 
 	return body
 }
 
-// mergeEmailMetadata merges the email thread block from emailBlock into the
-// existing message metadata, preserving unrelated keys (ticketer_id,
-// chats_msg_uuid, etc.). Returns nil when emailBlock is empty.
+// mergeEmailMetadata merges keys from emailBlock into existing message
+// metadata, preserving unrelated keys (ticketer_id, chats_msg_uuid, etc.).
+// emailBlock is expected to be a well-formed JSON object (as produced by
+// buildOutboundThreadMetadata). Returns nil when emailBlock is empty.
 func mergeEmailMetadata(existing, emailBlock json.RawMessage) json.RawMessage {
 	if len(emailBlock) == 0 {
 		return nil
 	}
-
-	var emailWrapper struct {
-		Email json.RawMessage `json:"email"`
-	}
-	if err := json.Unmarshal(emailBlock, &emailWrapper); err != nil || len(emailWrapper.Email) == 0 {
+	var src map[string]json.RawMessage
+	if err := json.Unmarshal(emailBlock, &src); err != nil || len(src) == 0 {
 		return nil
 	}
-
-	merged := map[string]interface{}{}
+	dst := map[string]json.RawMessage{}
 	if len(existing) > 0 {
-		if err := json.Unmarshal(existing, &merged); err != nil {
-			// existing isn't a JSON object; fall back to the email block alone
+		if err := json.Unmarshal(existing, &dst); err != nil {
 			return emailBlock
 		}
 	}
-	var emailValue interface{}
-	if err := json.Unmarshal(emailWrapper.Email, &emailValue); err != nil {
-		return nil
+	for k, v := range src {
+		dst[k] = v
 	}
-	merged["email"] = emailValue
-
-	out, err := json.Marshal(merged)
+	out, err := json.Marshal(dst)
 	if err != nil {
 		return emailBlock
 	}

--- a/handlers/email/email_test.go
+++ b/handlers/email/email_test.go
@@ -53,7 +53,7 @@ func urnWithTag(address, anchor string) string {
 var receiveTestCases = []ChannelHandleTestCase{
 	{Label: "Receive plain without threading",
 		URL: receiveURL, Data: plainReceive, Status: 200, Response: "Message Accepted",
-		Text: Sp("Hi there"), URN: Sp("mailto:client@example.com"), ExternalID: Sp(""),
+		Name: Sp("client@example.com"), Text: Sp("Hi there"), URN: Sp("mailto:client@example.com"), ExternalID: Sp(""),
 		Metadata: Jp(map[string]interface{}{
 			"email": map[string]interface{}{
 				"subject": "Hello",
@@ -62,7 +62,7 @@ var receiveTestCases = []ChannelHandleTestCase{
 
 	{Label: "Receive with message_id only",
 		URL: receiveURL, Data: messageIDOnly, Status: 200, Response: "Message Accepted",
-		Text: Sp("First message"), URN: Sp(urnWithTag("client@example.com", "<first@example.com>")),
+		Name: Sp("client@example.com"), Text: Sp("First message"), URN: Sp(urnWithTag("client@example.com", "<first@example.com>")),
 		ExternalID: Sp("<first@example.com>"),
 		Metadata: Jp(map[string]interface{}{
 			"email": map[string]interface{}{
@@ -72,7 +72,7 @@ var receiveTestCases = []ChannelHandleTestCase{
 
 	{Label: "Receive with full threading",
 		URL: receiveURL, Data: threadedReceive, Status: 200, Response: "Message Accepted",
-		Text: Sp("Resposta"), URN: Sp(urnWithTag("client@example.com", "<root@example.com>")),
+		Name: Sp("client@example.com"), Text: Sp("Resposta"), URN: Sp(urnWithTag("client@example.com", "<root@example.com>")),
 		ExternalID: Sp("<CABc@mail.gmail.com>"),
 		Metadata: Jp(map[string]interface{}{
 			"email": map[string]interface{}{
@@ -84,7 +84,7 @@ var receiveTestCases = []ChannelHandleTestCase{
 
 	{Label: "Receive normalizes missing angle brackets",
 		URL: receiveURL, Data: missingBrackets, Status: 200, Response: "Message Accepted",
-		Text: Sp("resp"), URN: Sp(urnWithTag("client@example.com", "root@example.com")),
+		Name: Sp("client@example.com"), Text: Sp("resp"), URN: Sp(urnWithTag("client@example.com", "root@example.com")),
 		ExternalID: Sp("<abc@example.com>"),
 		Metadata: Jp(map[string]interface{}{
 			"email": map[string]interface{}{
@@ -96,7 +96,7 @@ var receiveTestCases = []ChannelHandleTestCase{
 
 	{Label: "Receive dedupes references",
 		URL: receiveURL, Data: dupReferences, Status: 200, Response: "Message Accepted",
-		Text: Sp("resp"), URN: Sp(urnWithTag("client@example.com", "<root@x>")),
+		Name: Sp("client@example.com"), Text: Sp("resp"), URN: Sp(urnWithTag("client@example.com", "<root@x>")),
 		ExternalID: Sp("<a@x>"),
 		Metadata: Jp(map[string]interface{}{
 			"email": map[string]interface{}{
@@ -108,7 +108,7 @@ var receiveTestCases = []ChannelHandleTestCase{
 
 	{Label: "Receive accepts null references",
 		URL: receiveURL, Data: nullReferences, Status: 200, Response: "Message Accepted",
-		Text: Sp("resp"), URN: Sp(urnWithTag("client@example.com", "<b@x>")),
+		Name: Sp("client@example.com"), Text: Sp("resp"), URN: Sp(urnWithTag("client@example.com", "<b@x>")),
 		ExternalID: Sp("<a@x>"),
 		Metadata: Jp(map[string]interface{}{
 			"email": map[string]interface{}{
@@ -119,7 +119,7 @@ var receiveTestCases = []ChannelHandleTestCase{
 
 	{Label: "Receive accepts empty references",
 		URL: receiveURL, Data: emptyReferences, Status: 200, Response: "Message Accepted",
-		Text: Sp("resp"), URN: Sp(urnWithTag("client@example.com", "<b@x>")),
+		Name: Sp("client@example.com"), Text: Sp("resp"), URN: Sp(urnWithTag("client@example.com", "<b@x>")),
 		ExternalID: Sp("<a@x>"),
 		Metadata: Jp(map[string]interface{}{
 			"email": map[string]interface{}{
@@ -133,17 +133,17 @@ var receiveTestCases = []ChannelHandleTestCase{
 
 	{Label: "New thread on subject Meu Produto gets its own contact",
 		URL: receiveURL, Data: newThreadProduct, Status: 200, Response: "Message Accepted",
-		Text: Sp("Duvida sobre produto"), URN: Sp(urnWithTag("fulano123@gmail.com", "<produto@example.com>")),
+		Name: Sp("fulano123@gmail.com"), Text: Sp("Duvida sobre produto"), URN: Sp(urnWithTag("fulano123@gmail.com", "<produto@example.com>")),
 		ExternalID: Sp("<produto@example.com>")},
 
 	{Label: "New thread on subject Minha fatura gets a different contact",
 		URL: receiveURL, Data: newThreadInvoice, Status: 200, Response: "Message Accepted",
-		Text: Sp("Duvida sobre fatura"), URN: Sp(urnWithTag("fulano123@gmail.com", "<fatura@example.com>")),
+		Name: Sp("fulano123@gmail.com"), Text: Sp("Duvida sobre fatura"), URN: Sp(urnWithTag("fulano123@gmail.com", "<fatura@example.com>")),
 		ExternalID: Sp("<fatura@example.com>")},
 
 	{Label: "Reply to Meu Produto thread resolves back to that same contact",
 		URL: receiveURL, Data: replyToProduct, Status: 200, Response: "Message Accepted",
-		Text: Sp("Resposta produto"), URN: Sp(urnWithTag("fulano123@gmail.com", "<produto@example.com>")),
+		Name: Sp("fulano123@gmail.com"), Text: Sp("Resposta produto"), URN: Sp(urnWithTag("fulano123@gmail.com", "<produto@example.com>")),
 		ExternalID: Sp("<produto-reply@example.com>")},
 }
 

--- a/handlers/email/email_test.go
+++ b/handlers/email/email_test.go
@@ -333,3 +333,57 @@ func seedParents(mb *courier.MockBackend) {
 func TestSending(t *testing.T) {
 	RunChannelSendTestCases(t, defaultChannel, newHandler(), defaultSendTestCases, seedParents)
 }
+
+func TestMergeEmailMetadata(t *testing.T) {
+	emailBlock := json.RawMessage(`{"email":{"in_reply_to":"<a@x>","references":["<a@x>"],"subject":"Re: Hi"}}`)
+
+	t.Run("empty emailBlock returns nil", func(t *testing.T) {
+		if got := mergeEmailMetadata(json.RawMessage(`{"ticketer_id":1}`), nil); got != nil {
+			t.Fatalf("expected nil, got %s", got)
+		}
+	})
+
+	t.Run("empty object emailBlock returns nil", func(t *testing.T) {
+		if got := mergeEmailMetadata(nil, json.RawMessage(`{}`)); got != nil {
+			t.Fatalf("expected nil, got %s", got)
+		}
+	})
+
+	t.Run("nil existing returns emailBlock", func(t *testing.T) {
+		got := mergeEmailMetadata(nil, emailBlock)
+		assertJSONEqual(t, emailBlock, got)
+	})
+
+	t.Run("preserves unrelated existing keys", func(t *testing.T) {
+		existing := json.RawMessage(`{"ticketer_id":1,"chats_msg_uuid":"abc"}`)
+		got := mergeEmailMetadata(existing, emailBlock)
+		assertJSONEqual(t, json.RawMessage(`{"chats_msg_uuid":"abc","email":{"in_reply_to":"<a@x>","references":["<a@x>"],"subject":"Re: Hi"},"ticketer_id":1}`), got)
+	})
+
+	t.Run("overwrites existing email key", func(t *testing.T) {
+		existing := json.RawMessage(`{"email":{"subject":"Old"},"ticketer_id":1}`)
+		got := mergeEmailMetadata(existing, emailBlock)
+		assertJSONEqual(t, json.RawMessage(`{"email":{"in_reply_to":"<a@x>","references":["<a@x>"],"subject":"Re: Hi"},"ticketer_id":1}`), got)
+	})
+
+	t.Run("invalid existing falls back to emailBlock", func(t *testing.T) {
+		got := mergeEmailMetadata(json.RawMessage(`["not","object"]`), emailBlock)
+		assertJSONEqual(t, emailBlock, got)
+	})
+}
+
+func assertJSONEqual(t *testing.T, want, got json.RawMessage) {
+	t.Helper()
+	var wantVal, gotVal interface{}
+	if err := json.Unmarshal(want, &wantVal); err != nil {
+		t.Fatalf("want unmarshal: %v", err)
+	}
+	if err := json.Unmarshal(got, &gotVal); err != nil {
+		t.Fatalf("got unmarshal: %v\ngot=%s", err, got)
+	}
+	wantJSON, _ := json.Marshal(wantVal)
+	gotJSON, _ := json.Marshal(gotVal)
+	if string(wantJSON) != string(gotJSON) {
+		t.Fatalf("mismatch\nwant: %s\ngot:  %s", wantJSON, gotJSON)
+	}
+}

--- a/handlers/email/email_test.go
+++ b/handlers/email/email_test.go
@@ -222,6 +222,17 @@ var defaultSendTestCases = []ChannelSendTestCase{
 		ResponseToExternalID: "<root@x>",
 		Status:               "W",
 		RequestBody:          `{"uuid":"00000000-0000-0000-0000-000000000000","from":"test@example.com","to":"client@example.com","body":"Reply body","subject":"Re: Pedido #123","channel_uuid":"8eb23e93-5ecb-45ba-b726-3b064e0c56ab","in_reply_to":"<root@x>","references":["<root@x>"]}`,
+		StatusMetadata:       json.RawMessage(`{"email":{"in_reply_to":"<root@x>","references":["<root@x>"],"subject":"Re: Pedido #123"}}`),
+		ResponseBody:         `{"status":"sent"}`, ResponseStatus: 200,
+		SendPrep: setSendURL},
+
+	{Label: "Send subsequent message reuses subject and extends references from prior outbound",
+		Text: "Follow-up details", URN: "mailto:client@example.com",
+		ResponseToExternalID: "<outbound1@x>",
+		Metadata:             json.RawMessage(`{"ticketer_id":1}`),
+		Status:               "W",
+		RequestBody:          `{"uuid":"00000000-0000-0000-0000-000000000000","from":"test@example.com","to":"client@example.com","body":"Follow-up details","subject":"Re: Pedido #123","channel_uuid":"8eb23e93-5ecb-45ba-b726-3b064e0c56ab","in_reply_to":"<outbound1@x>","references":["<root@x>","<outbound1@x>"]}`,
+		StatusMetadata:       json.RawMessage(`{"email":{"in_reply_to":"<outbound1@x>","references":["<root@x>","<outbound1@x>"],"subject":"Re: Pedido #123"},"ticketer_id":1}`),
 		ResponseBody:         `{"status":"sent"}`, ResponseStatus: 200,
 		SendPrep: setSendURL},
 
@@ -303,6 +314,14 @@ func seedParents(mb *courier.MockBackend) {
 		WithMetadata(json.RawMessage(`{"email":{"subject":"Via ID"}}`))
 	mb.AddMsgByID(parentViaID)
 	mb.AddMsgByExternalID(parentViaID)
+
+	// prior outbound that already stashed thread metadata (what SendMsg now
+	// writes after a successful reply) — subsequent sends resolve this as
+	// parent and must keep the same subject / extend References
+	priorOutbound := mb.NewIncomingMsg(defaultChannel, urns.URN("mailto:client@example.com"), "First reply").
+		WithExternalID("<outbound1@x>").
+		WithMetadata(json.RawMessage(`{"email":{"in_reply_to":"<root@x>","references":["<root@x>"],"subject":"Re: Pedido #123"}}`))
+	mb.AddMsgByExternalID(priorOutbound)
 
 	lastInbound := mb.NewIncomingMsg(defaultChannel, urns.URN("mailto:ticket@example.com"), "Help").
 		WithExternalID("<ticket-inbound@x>").

--- a/handlers/test.go
+++ b/handlers/test.go
@@ -110,6 +110,9 @@ type ChannelSendTestCase struct {
 	Error      string
 	Status     string
 	ExternalID string
+	// StatusMetadata, when set, is compared with require.JSONEq against the
+	// metadata attached to the MsgStatus returned by SendMsg.
+	StatusMetadata json.RawMessage
 
 	Stopped bool
 
@@ -351,6 +354,11 @@ func RunChannelSendTestCases(t *testing.T, channel courier.Channel, handler cour
 
 			if testCase.ExternalID != "" {
 				require.Equal(testCase.ExternalID, status.ExternalID())
+			}
+
+			if len(testCase.StatusMetadata) > 0 {
+				require.NotNil(status, "status should not be nil")
+				require.JSONEq(string(testCase.StatusMetadata), string(status.Metadata()))
 			}
 
 			if testCase.Status != "" {

--- a/status.go
+++ b/status.go
@@ -44,9 +44,16 @@ type MsgStatus interface {
 	SetStatus(MsgStatusValue)
 
 	// Metadata returns the metadata of the underlying message row, when the
-	// backend populates it (e.g. via the RETURNING clause of the status update).
+	// backend populates it (e.g. via the RETURNING clause of the status update)
+	// or when SetMetadata was called by a handler before WriteMsgStatus.
 	// Returns nil when not available.
 	Metadata() json.RawMessage
+
+	// SetMetadata attaches metadata to be persisted by WriteMsgStatus. Handlers
+	// (e.g. email) use this to stash thread context on an outbound message so a
+	// subsequent send can rebuild In-Reply-To/References/subject. Passing nil or
+	// empty leaves the existing DB metadata unchanged.
+	SetMetadata(json.RawMessage)
 
 	Logs() []*ChannelLog
 	AddLog(log *ChannelLog)


### PR DESCRIPTION
Subsequent replies were starting new threads because the parent
outbound had no metadata.email for subject/References reuse.