### PR TITLE
feat: add GetContactFieldValue method to Backend interface and implement related functionality

### DIFF
--- a/WENI-CHANGELOG.md
+++ b/WENI-CHANGELOG.md
@@ -1,3 +1,7 @@
+1.62.0
+----------
+ * feat: add GetContactFieldValue method to Backend interface and implement related functionality
+
 1.61.0
 ----------
  * feat: Persist email thread metadata on outbound sends so subsequent replies reuse subject and extend References instead of starting a new thread

--- a/WENI-CHANGELOG.md
+++ b/WENI-CHANGELOG.md
@@ -1,6 +1,7 @@
 1.62.0
 ----------
  * feat: add GetContactFieldValue method to Backend interface and implement related functionality
+ * feat: add ReplaceWhatsAppBSUIDOnContact method to manage WhatsApp BSUID URNs
 
 1.61.0
 ----------

--- a/backend.go
+++ b/backend.go
@@ -39,6 +39,9 @@ type Backend interface {
 	// FindContact looks up a contact by URN without creating one. Returns ErrContactNotFound if none exists.
 	FindContact(context context.Context, channel Channel, urn urns.URN) (Contact, error)
 
+	// GetContactFieldValue returns the current text value for a contact field key, or empty if unset.
+	GetContactFieldValue(context.Context, Channel, Contact, string) (string, error)
+
 	// IsEmailMailboxBlocked reports whether any active contact in the channel's
 	// org is blocked for the given real mailbox address — either the exact
 	// mailto: URN or any synthetic +wt-<8hex> thread variant derived from it.

--- a/backends/rapidpro/backend.go
+++ b/backends/rapidpro/backend.go
@@ -83,6 +83,17 @@ func (b *backend) FindContact(ctx context.Context, c courier.Channel, urn urns.U
 	return contact, nil
 }
 
+// GetContactFieldValue returns the current text value for a contact field key.
+func (b *backend) GetContactFieldValue(ctx context.Context, c courier.Channel, contact courier.Contact, fieldKey string) (string, error) {
+	dbChannel := c.(*DBChannel)
+	dbContact := contact.(*DBContact)
+
+	timeout, cancel := context.WithTimeout(ctx, backendTimeout)
+	defer cancel()
+
+	return getContactFieldValue(timeout, b.db, dbChannel.OrgID_, dbContact.ID_, fieldKey)
+}
+
 // IsEmailMailboxBlocked reports whether any active blocked contact in the
 // channel's org matches the real mailbox or a +wt- thread variant of it.
 func (b *backend) IsEmailMailboxBlocked(ctx context.Context, c courier.Channel, address string) (bool, error) {

--- a/backends/rapidpro/contact.go
+++ b/backends/rapidpro/contact.go
@@ -188,6 +188,25 @@ func findContactByURN(ctx context.Context, b *backend, org OrgID, urn urns.URN) 
 	return contact, nil
 }
 
+const getContactFieldValueSQL = `
+SELECT c.fields->cf.uuid::text->>'text'
+FROM contacts_contact c
+JOIN contacts_contactfield cf ON cf.org_id = c.org_id AND cf.key = $3 AND cf.is_active = TRUE
+WHERE c.org_id = $1 AND c.id = $2
+`
+
+func getContactFieldValue(ctx context.Context, db *sqlx.DB, orgID OrgID, contactID ContactID, fieldKey string) (string, error) {
+	var value null.String
+	err := db.GetContext(ctx, &value, getContactFieldValueSQL, orgID, contactID, fieldKey)
+	if err == sql.ErrNoRows {
+		return "", nil
+	}
+	if err != nil {
+		return "", err
+	}
+	return string(value), nil
+}
+
 const isEmailMailboxBlockedSQL = `
 SELECT EXISTS (
 	SELECT 1

--- a/handlers/facebookapp/facebookapp.go
+++ b/handlers/facebookapp/facebookapp.go
@@ -158,6 +158,13 @@ var integrationWebhookFields = map[string]bool{
 	"template_correct_category_detection": true,
 }
 
+const (
+	wacBusinessUsernameUpdatesField = "business_username_updates"
+	wacUsernameStatusApproved       = "approved"
+	configKeyWAUsername             = "wa_username"
+	contactFieldWAUsername          = "whatsapp_username"
+)
+
 func newHandler(channelType courier.ChannelType, name string, useUUIDRoutes bool) courier.ChannelHandler {
 	return &handler{handlers.NewBaseHandlerWithParams(channelType, name, useUUIDRoutes)}
 }
@@ -394,6 +401,8 @@ type moPayload struct {
 				CurrentLimit                 string `json:"current_limit"`
 				Decision                     string `json:"decision"`
 				DisplayPhoneNumber           string `json:"display_phone_number"`
+				Username                     string `json:"username"`
+				Status                       string `json:"status"`
 				Event                        string `json:"event"`
 				MaxDailyConversationPerPhone int    `json:"max_daily_conversation_per_phone"`
 				MaxPhoneNumbersPerBusiness   int    `json:"max_phone_numbers_per_business"`
@@ -574,22 +583,6 @@ func processWACButtonMetadata(button *struct {
 		},
 	}
 }
-
-// addSecondaryURN creates a WhatsApp URN from the given identifier and adds it
-// to the contact that owns primaryURN. Errors are silently ignored so that a
-// failure to attach a secondary URN never blocks message processing.
-func (h *handler) addSecondaryURN(ctx context.Context, channel courier.Channel, primaryURN urns.URN, identifier string) {
-	secondaryURN, err := urns.NewWhatsAppURN(identifier)
-	if err != nil {
-		return
-	}
-	contact, err := h.Backend().GetContact(ctx, channel, primaryURN, "", "")
-	if err != nil {
-		return
-	}
-	h.Backend().AddURNtoContact(ctx, channel, contact, secondaryURN)
-}
-
 type bsuidUpdate struct {
 	Previous string
 	Current  string
@@ -628,6 +621,77 @@ func (h *handler) processUserIDURNUpdate(ctx context.Context, channel courier.Ch
 		Infof("user_id_update: successfully updated %s URN", label)
 
 	return fmt.Sprintf("user_id_update: %s updated from %s to %s", label, upd.Previous, upd.Current), nil
+}
+
+// processBusinessUsernameUpdate stores the approved business username on the channel config.
+func (h *handler) processBusinessUsernameUpdate(ctx context.Context, channel courier.Channel, username, status string) (string, error) {
+	if status != wacUsernameStatusApproved {
+		return fmt.Sprintf("business_username_updates: ignoring status %q", status), nil
+	}
+
+	newUsername := username
+	if newUsername == "" {
+		return "", fmt.Errorf("business_username_updates: missing username")
+	}
+
+	oldUsername := channel.StringConfigForKey(configKeyWAUsername, "")
+
+	config := channel.Config()
+	mergedConfig := make(map[string]interface{}, len(config)+1)
+	for key, value := range config {
+		mergedConfig[key] = value
+	}
+	mergedConfig[configKeyWAUsername] = newUsername
+
+	if err := h.Backend().UpdateChannelConfig(ctx, channel, mergedConfig); err != nil {
+		return "", err
+	}
+
+	return fmt.Sprintf("business_username_updates: username updated from %s to %s", oldUsername, newUsername), nil
+}
+
+// processContactUsernameUpdate updates the contact whatsapp_username field when the incoming
+// value differs from what is currently stored. Returns a human-readable info string on success.
+func (h *handler) processContactUsernameUpdate(ctx context.Context, channel courier.Channel, urn urns.URN, newUsername string) (string, error) {
+	if newUsername == "" {
+		return "", nil
+	}
+
+	contact, err := h.Backend().FindContact(ctx, channel, urn)
+	if err == courier.ErrContactNotFound {
+		return "", nil
+	}
+	if err != nil {
+		return "", fmt.Errorf("username_update: contact lookup failed: %w", err)
+	}
+
+	oldUsername, err := h.Backend().GetContactFieldValue(ctx, channel, contact, contactFieldWAUsername)
+	if err != nil {
+		return "", fmt.Errorf("username_update: failed to read current username: %w", err)
+	}
+	if oldUsername == newUsername {
+		return "", nil
+	}
+
+	externalID := fmt.Sprintf("username_update:%s:%s:%s", channel.UUID(), urn.Identity(), newUsername)
+	msg := h.Backend().NewIncomingMsg(channel, urn, "").
+		WithNewContactFields(map[string]string{contactFieldWAUsername: newUsername}).
+		WithExternalID(externalID).
+		WithReceivedOn(time.Now().UTC())
+
+	if err := h.Backend().WriteMsg(ctx, msg); err != nil {
+		return "", fmt.Errorf("username_update: failed to write update: %w", err)
+	}
+
+	logrus.WithField("channel_uuid", channel.UUID()).
+		WithField("old_username", oldUsername).
+		WithField("new_username", newUsername).
+		Info("username_update: successfully updated contact username")
+
+	if oldUsername == "" {
+		return fmt.Sprintf("username_update: username set to %s", newUsername), nil
+	}
+	return fmt.Sprintf("username_update: username updated from %s to %s", oldUsername, newUsername), nil
 }
 
 // addMetadataWithOverwrite adds metadata to both the root level and overwrite_message field
@@ -773,6 +837,9 @@ func (h *handler) GetChannel(ctx context.Context, r *http.Request) (courier.Chan
 				courier.LogRequestError(r, nil, fmt.Errorf("could not send template webhook: %s", er))
 			}
 			return nil, fmt.Errorf("template update, so ignore")
+		}
+		if payload.Entry[0].Changes[0].Value.Metadata == nil {
+			return nil, fmt.Errorf("no channel address found")
 		}
 		channelAddress = payload.Entry[0].Changes[0].Value.Metadata.PhoneNumberID
 		if channelAddress == "" {
@@ -942,6 +1009,17 @@ func (h *handler) processCloudWhatsAppPayload(ctx context.Context, channel couri
 
 		for _, change := range entry.Changes {
 
+			if change.Field == wacBusinessUsernameUpdatesField {
+				info, err := h.processBusinessUsernameUpdate(ctx, channel, change.Value.Username, change.Value.Status)
+				if err != nil {
+					logrus.WithField("channel_uuid", channel.UUID()).WithError(err).Warn(err.Error())
+					data = append(data, courier.NewInfoData(err.Error()))
+					continue
+				}
+				data = append(data, courier.NewInfoData(info))
+				continue
+			}
+
 			for _, contact := range change.Value.Contacts {
 				if contact.WaID != "" {
 					contactNames[contact.WaID] = contact.Profile.Name
@@ -950,11 +1028,14 @@ func (h *handler) processCloudWhatsAppPayload(ctx context.Context, channel couri
 					contactNames[contact.UserID] = contact.Profile.Name
 				}
 				if contact.Profile.Username != "" {
-					if contact.WaID != "" {
-						contactUsernames[contact.WaID] = contact.Profile.Username
-					}
-					if contact.UserID != "" {
-						contactUsernames[contact.UserID] = contact.Profile.Username
+					username := contact.Profile.Username
+					if username != "" {
+						if contact.WaID != "" {
+							contactUsernames[contact.WaID] = username
+						}
+						if contact.UserID != "" {
+							contactUsernames[contact.UserID] = username
+						}
 					}
 				}
 			}
@@ -1078,17 +1159,14 @@ func (h *handler) processCloudWhatsAppPayload(ctx context.Context, channel couri
 				// create our message
 				ev := h.Backend().NewIncomingMsg(channel, urn, text).WithReceivedOn(date).WithExternalID(msg.ID).WithContactName(contactName)
 
-				// store username as contact field
-				contactFields := map[string]string{}
 				username := contactUsernames[msg.From]
 				if username == "" {
 					username = contactUsernames[msg.FromUserID]
 				}
 				if username != "" {
-					contactFields["whatsapp_username"] = username
-				}
-				if len(contactFields) > 0 {
-					ev.WithNewContactFields(contactFields)
+					if _, err := h.Backend().FindContact(ctx, channel, urn); err == courier.ErrContactNotFound {
+						ev.WithNewContactFields(map[string]string{contactFieldWAUsername: username})
+					}
 				}
 
 				event := h.Backend().CheckExternalIDSeen(ev)
@@ -1167,6 +1245,14 @@ func (h *handler) processCloudWhatsAppPayload(ctx context.Context, channel couri
 					return nil, nil, err
 				}
 
+				if username != "" {
+					if info, usernameErr := h.processContactUsernameUpdate(ctx, channel, urn, username); usernameErr != nil {
+						logrus.WithField("channel_uuid", channel.UUID()).WithError(usernameErr).Warn(usernameErr.Error())
+					} else if info != "" {
+						data = append(data, courier.NewInfoData(info))
+					}
+				}
+
 				// add secondary URN (phone or BSUID) after contact is persisted
 				if secondaryURN != urns.NilURN {
 					contact, contactErr := h.Backend().GetContact(ctx, channel, urn, "", "")
@@ -1207,13 +1293,22 @@ func (h *handler) processCloudWhatsAppPayload(ctx context.Context, channel couri
 					return nil, nil, err
 				}
 
+				recipientID := status.RecipientID
+				if recipientID == "" {
+					recipientID = status.RecipientUserID
+				}
+				if username := contactUsernames[recipientID]; username != "" {
+					if recipientURN, urnErr := urns.NewWhatsAppURN(recipientID); urnErr != nil {
+						handlers.WriteAndLogRequestError(ctx, h, channel, w, r, urnErr)
+					} else if info, usernameErr := h.processContactUsernameUpdate(ctx, channel, recipientURN, username); usernameErr != nil {
+						logrus.WithField("channel_uuid", channel.UUID()).WithError(usernameErr).Warn(usernameErr.Error())
+					} else if info != "" {
+						data = append(data, courier.NewInfoData(info))
+					}
+				}
+
 				if (msgStatus == courier.MsgDelivered || msgStatus == courier.MsgRead) &&
 					channel.Address() != h.Server().Config().WhatsappCloudDemoAddress {
-
-					recipientID := status.RecipientID
-					if recipientID == "" {
-						recipientID = status.RecipientUserID
-					}
 
 					if recipientID != "" {
 						urn, err := urns.NewWhatsAppURN(recipientID)

--- a/handlers/facebookapp/facebookapp.go
+++ b/handlers/facebookapp/facebookapp.go
@@ -650,48 +650,37 @@ func (h *handler) processBusinessUsernameUpdate(ctx context.Context, channel cou
 	return fmt.Sprintf("business_username_updates: username updated from %s to %s", oldUsername, newUsername), nil
 }
 
-// processContactUsernameUpdate updates the contact whatsapp_username field when the incoming
-// value differs from what is currently stored. Returns a human-readable info string on success.
-func (h *handler) processContactUsernameUpdate(ctx context.Context, channel courier.Channel, urn urns.URN, newUsername string) (string, error) {
+// contactUsernameFieldsIfChanged returns whatsapp_username fields to apply when newUsername
+// differs from the stored value. For new contacts the fields are returned so they can be
+// attached to the incoming message.
+func (h *handler) contactUsernameFieldsIfChanged(ctx context.Context, channel courier.Channel, urn urns.URN, newUsername string) (map[string]string, string, error) {
 	if newUsername == "" {
-		return "", nil
+		return nil, "", nil
 	}
 
 	contact, err := h.Backend().FindContact(ctx, channel, urn)
 	if err == courier.ErrContactNotFound {
-		return "", nil
+		return map[string]string{contactFieldWAUsername: newUsername},
+			fmt.Sprintf("username_update: username set to %s", newUsername), nil
 	}
 	if err != nil {
-		return "", fmt.Errorf("username_update: contact lookup failed: %w", err)
+		return nil, "", fmt.Errorf("username_update: contact lookup failed: %w", err)
 	}
 
 	oldUsername, err := h.Backend().GetContactFieldValue(ctx, channel, contact, contactFieldWAUsername)
 	if err != nil {
-		return "", fmt.Errorf("username_update: failed to read current username: %w", err)
+		return nil, "", fmt.Errorf("username_update: failed to read current username: %w", err)
 	}
 	if oldUsername == newUsername {
-		return "", nil
+		return nil, "", nil
 	}
 
-	externalID := fmt.Sprintf("username_update:%s:%s:%s", channel.UUID(), urn.Identity(), newUsername)
-	msg := h.Backend().NewIncomingMsg(channel, urn, "").
-		WithNewContactFields(map[string]string{contactFieldWAUsername: newUsername}).
-		WithExternalID(externalID).
-		WithReceivedOn(time.Now().UTC())
-
-	if err := h.Backend().WriteMsg(ctx, msg); err != nil {
-		return "", fmt.Errorf("username_update: failed to write update: %w", err)
-	}
-
-	logrus.WithField("channel_uuid", channel.UUID()).
-		WithField("old_username", oldUsername).
-		WithField("new_username", newUsername).
-		Info("username_update: successfully updated contact username")
-
+	info := fmt.Sprintf("username_update: username updated from %s to %s", oldUsername, newUsername)
 	if oldUsername == "" {
-		return fmt.Sprintf("username_update: username set to %s", newUsername), nil
+		info = fmt.Sprintf("username_update: username set to %s", newUsername)
 	}
-	return fmt.Sprintf("username_update: username updated from %s to %s", oldUsername, newUsername), nil
+
+	return map[string]string{contactFieldWAUsername: newUsername}, info, nil
 }
 
 // addMetadataWithOverwrite adds metadata to both the root level and overwrite_message field
@@ -1163,9 +1152,13 @@ func (h *handler) processCloudWhatsAppPayload(ctx context.Context, channel couri
 				if username == "" {
 					username = contactUsernames[msg.FromUserID]
 				}
+				var usernameUpdateInfo string
 				if username != "" {
-					if _, err := h.Backend().FindContact(ctx, channel, urn); err == courier.ErrContactNotFound {
-						ev.WithNewContactFields(map[string]string{contactFieldWAUsername: username})
+					if fields, info, usernameErr := h.contactUsernameFieldsIfChanged(ctx, channel, urn, username); usernameErr != nil {
+						logrus.WithField("channel_uuid", channel.UUID()).WithError(usernameErr).Warn(usernameErr.Error())
+					} else if fields != nil {
+						ev.WithNewContactFields(fields)
+						usernameUpdateInfo = info
 					}
 				}
 
@@ -1245,12 +1238,8 @@ func (h *handler) processCloudWhatsAppPayload(ctx context.Context, channel couri
 					return nil, nil, err
 				}
 
-				if username != "" {
-					if info, usernameErr := h.processContactUsernameUpdate(ctx, channel, urn, username); usernameErr != nil {
-						logrus.WithField("channel_uuid", channel.UUID()).WithError(usernameErr).Warn(usernameErr.Error())
-					} else if info != "" {
-						data = append(data, courier.NewInfoData(info))
-					}
+				if usernameUpdateInfo != "" {
+					data = append(data, courier.NewInfoData(usernameUpdateInfo))
 				}
 
 				// add secondary URN (phone or BSUID) after contact is persisted
@@ -1296,15 +1285,6 @@ func (h *handler) processCloudWhatsAppPayload(ctx context.Context, channel couri
 				recipientID := status.RecipientID
 				if recipientID == "" {
 					recipientID = status.RecipientUserID
-				}
-				if username := contactUsernames[recipientID]; username != "" {
-					if recipientURN, urnErr := urns.NewWhatsAppURN(recipientID); urnErr != nil {
-						handlers.WriteAndLogRequestError(ctx, h, channel, w, r, urnErr)
-					} else if info, usernameErr := h.processContactUsernameUpdate(ctx, channel, recipientURN, username); usernameErr != nil {
-						logrus.WithField("channel_uuid", channel.UUID()).WithError(usernameErr).Warn(usernameErr.Error())
-					} else if info != "" {
-						data = append(data, courier.NewInfoData(info))
-					}
 				}
 
 				if (msgStatus == courier.MsgDelivered || msgStatus == courier.MsgRead) &&

--- a/handlers/facebookapp/facebookapp_test.go
+++ b/handlers/facebookapp/facebookapp_test.go
@@ -2073,3 +2073,88 @@ func TestWaTemplateTypeFromMetadata(t *testing.T) {
 		})
 	}
 }
+
+func TestContactUsernameUpdate(t *testing.T) {
+	channel := courier.NewMockChannel(
+		"8eb23e93-5ecb-45ba-b726-3b064e0c568c",
+		"WAC",
+		"12345",
+		"",
+		map[string]interface{}{courier.ConfigAuthToken: "a123"},
+	)
+
+	RunChannelTestCases(t, []courier.Channel{channel}, newHandler("WAC", "WhatsApp Cloud", false), []ChannelHandleTestCase{
+		{
+			Label:                 "Receive Message BSUID Username Update",
+			URL:                   wacReceiveURL,
+			Data:                  string(courier.ReadFile("./testdata/wac/helloBSUIDUsername.json")),
+			Status:                200,
+			Response:              `"username_update: username updated from olduser to @kerryfisher"`,
+			NoQueueErrorCheck:     true,
+			NoInvalidChannelCheck: true,
+			PrepRequest:           addValidSignatureWAC,
+			PrepBackend: func(mb *courier.MockBackend) {
+				bsuidURN, err := urns.NewWhatsAppURN("US.13491208655302741918")
+				assert.NoError(t, err)
+				mb.GetContact(context.Background(), channel, bsuidURN, "", "")
+				mb.SetContactFieldValue(bsuidURN, "whatsapp_username", "olduser")
+			},
+		},
+	})
+}
+
+func TestBusinessUsernameUpdatesApproved(t *testing.T) {
+	channel := courier.NewMockChannel(
+		"8eb23e93-5ecb-45ba-b726-3b064e0c568c",
+		"WAC",
+		"12345",
+		"",
+		map[string]interface{}{
+			courier.ConfigAuthToken: "a123",
+			"wa_username":           "oldusername",
+		},
+	)
+
+	RunChannelTestCases(t, []courier.Channel{channel}, newHandler("WAC", "WhatsApp Cloud", false), []ChannelHandleTestCase{
+		{
+			Label:                 "Receive Business Username Update Approved",
+			URL:                   wacReceiveURL,
+			Data:                  string(courier.ReadFile("./testdata/wac/businessUsernameUpdatesWAC.json")),
+			Status:                200,
+			Response:              `"business_username_updates: username updated from oldusername to jaspersmarket"`,
+			NoQueueErrorCheck:     true,
+			NoInvalidChannelCheck: true,
+			PrepRequest:           addValidSignatureWAC,
+		},
+	})
+
+	assert.Equal(t, "jaspersmarket", channel.StringConfigForKey("wa_username", ""))
+}
+
+func TestBusinessUsernameUpdatesReserved(t *testing.T) {
+	channel := courier.NewMockChannel(
+		"8eb23e93-5ecb-45ba-b726-3b064e0c568c",
+		"WAC",
+		"12345",
+		"",
+		map[string]interface{}{
+			courier.ConfigAuthToken: "a123",
+			"wa_username":           "oldusername",
+		},
+	)
+
+	RunChannelTestCases(t, []courier.Channel{channel}, newHandler("WAC", "WhatsApp Cloud", false), []ChannelHandleTestCase{
+		{
+			Label:                 "Ignore Business Username Update Reserved",
+			URL:                   wacReceiveURL,
+			Data:                  string(courier.ReadFile("./testdata/wac/businessUsernameUpdatesReservedWAC.json")),
+			Status:                200,
+			Response:              `"business_username_updates: ignoring status \"reserved\""`,
+			NoQueueErrorCheck:     true,
+			NoInvalidChannelCheck: true,
+			PrepRequest:           addValidSignatureWAC,
+		},
+	})
+
+	assert.Equal(t, "oldusername", channel.StringConfigForKey("wa_username", ""))
+}

--- a/handlers/facebookapp/testdata/wac/businessUsernameUpdatesReservedWAC.json
+++ b/handlers/facebookapp/testdata/wac/businessUsernameUpdatesReservedWAC.json
@@ -1,0 +1,23 @@
+{
+  "object": "whatsapp_business_account",
+  "entry": [
+    {
+      "id": "8856996819413533",
+      "time": 1739321024,
+      "changes": [
+        {
+          "field": "business_username_updates",
+          "value": {
+            "metadata": {
+              "display_phone_number": "+250 788 123 200",
+              "phone_number_id": "12345"
+            },
+            "display_phone_number": "+250 788 123 200",
+            "username": "jaspersmarket",
+            "status": "reserved"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/handlers/facebookapp/testdata/wac/businessUsernameUpdatesWAC.json
+++ b/handlers/facebookapp/testdata/wac/businessUsernameUpdatesWAC.json
@@ -1,0 +1,23 @@
+{
+  "object": "whatsapp_business_account",
+  "entry": [
+    {
+      "id": "8856996819413533",
+      "time": 1739321024,
+      "changes": [
+        {
+          "field": "business_username_updates",
+          "value": {
+            "metadata": {
+              "display_phone_number": "+250 788 123 200",
+              "phone_number_id": "12345"
+            },
+            "display_phone_number": "+250 788 123 200",
+            "username": "jaspersmarket",
+            "status": "approved"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/test.go
+++ b/test.go
@@ -861,7 +861,7 @@ func (m *mockMsg) WithNewContactFields(fields map[string]string) Msg {
 	m.newContactFields = fields
 	return m
 }
-func (m *mockMsg) WithURNAuth(auth string) Msg       { m.urnAuth = auth; return m }
+func (m *mockMsg) WithURNAuth(auth string) Msg { m.urnAuth = auth; return m }
 func (m *mockMsg) WithReceivedOn(date time.Time) Msg { m.receivedOn = &date; return m }
 func (m *mockMsg) WithExternalID(id string) Msg      { m.externalID = id; return m }
 func (m *mockMsg) WithID(id MsgID) Msg               { m.id = id; return m }

--- a/test.go
+++ b/test.go
@@ -67,6 +67,9 @@ type MockBackend struct {
 	// blockedEmailMailboxes is seeded by tests to back IsEmailMailboxBlocked;
 	// keyed by lowercased real mailbox address (no mailto: prefix).
 	blockedEmailMailboxes map[string]bool
+
+	// contactFieldValues tracks contact field values for GetContactFieldValue in tests.
+	contactFieldValues map[urns.URN]map[string]string
 }
 
 // NewMockBackend returns a new mock backend suitable for testing
@@ -284,6 +287,18 @@ func (mb *MockBackend) WriteMsg(ctx context.Context, m Msg) error {
 		uuid, _ := NewContactUUID(string(uuids.New()))
 		mb.contacts[m.URN()] = &mockContact{m.Channel(), m.URN(), m.URNAuth(), uuid}
 	}
+
+	if fields := m.NewContactFields(); len(fields) > 0 {
+		if mb.contactFieldValues == nil {
+			mb.contactFieldValues = make(map[urns.URN]map[string]string)
+		}
+		if mb.contactFieldValues[m.URN()] == nil {
+			mb.contactFieldValues[m.URN()] = make(map[string]string)
+		}
+		for key, value := range fields {
+			mb.contactFieldValues[m.URN()][key] = value
+		}
+	}
 	return nil
 }
 
@@ -398,6 +413,32 @@ func (mb *MockBackend) FindContact(ctx context.Context, channel Channel, urn urn
 		return nil, ErrContactNotFound
 	}
 	return contact, nil
+}
+
+// GetContactFieldValue returns the current text value for a contact field key.
+func (mb *MockBackend) GetContactFieldValue(ctx context.Context, channel Channel, contact Contact, fieldKey string) (string, error) {
+	mc, ok := contact.(*mockContact)
+	if !ok {
+		return "", nil
+	}
+	if mb.contactFieldValues == nil {
+		return "", nil
+	}
+	if fields, ok := mb.contactFieldValues[mc.urn]; ok {
+		return fields[fieldKey], nil
+	}
+	return "", nil
+}
+
+// SetContactFieldValue seeds a contact field value for tests.
+func (mb *MockBackend) SetContactFieldValue(urn urns.URN, fieldKey, value string) {
+	if mb.contactFieldValues == nil {
+		mb.contactFieldValues = make(map[urns.URN]map[string]string)
+	}
+	if mb.contactFieldValues[urn] == nil {
+		mb.contactFieldValues[urn] = make(map[string]string)
+	}
+	mb.contactFieldValues[urn][fieldKey] = value
 }
 
 // SetEmailMailboxBlocked marks a real mailbox as blocked for IsEmailMailboxBlocked tests.


### PR DESCRIPTION
- Introduced GetContactFieldValue method to retrieve the current text value for a contact field key.
- Updated MockBackend to support contact field value tracking and retrieval.
- Implemented GetContactFieldValue in the rapidpro backend to fetch values from the database.
- Added tests for business username updates in the Facebook app handler, including handling of approved and reserved statuses.
- Created test data for business username updates scenarios.