### PR TITLE
feat: Refactor WAC webhook routing to support batched multi-entry payloads

### DIFF
--- a/handlers/facebookapp/facebookapp.go
+++ b/handlers/facebookapp/facebookapp.go
@@ -131,6 +131,47 @@ func waTemplateTypeFromMetadata(metadata json.RawMessage) (templateType string) 
 	return mapped
 }
 
+// wacWebhookRouting is the result of scanning every entry and change of a
+// whatsapp_business_account payload. Meta batches events, so a single request
+// can require forwarding to integrations and still carry message events that
+// belong to a channel.
+type wacWebhookRouting struct {
+	hasChanges     bool
+	toIntegrations bool
+	toFlows        bool
+	channelAddress string
+	multipleAddrs  bool
+}
+
+func routeWhatsAppChanges(payload *moPayload) wacWebhookRouting {
+	var routing wacWebhookRouting
+
+	for _, entry := range payload.Entry {
+		for _, change := range entry.Changes {
+			routing.hasChanges = true
+
+			if integrationWebhookFields[change.Field] {
+				routing.toIntegrations = true
+				continue
+			}
+			if change.Field == "flows" {
+				routing.toFlows = true
+				continue
+			}
+			if change.Value.Metadata == nil || change.Value.Metadata.PhoneNumberID == "" {
+				continue
+			}
+			if routing.channelAddress == "" {
+				routing.channelAddress = change.Value.Metadata.PhoneNumberID
+			} else if routing.channelAddress != change.Value.Metadata.PhoneNumberID {
+				routing.multipleAddrs = true
+			}
+		}
+	}
+
+	return routing
+}
+
 var waIgnoreStatuses = map[string]bool{
 	"deleted": true,
 }
@@ -841,50 +882,40 @@ func (h *handler) GetChannel(ctx context.Context, r *http.Request) (courier.Chan
 		channelAddress = payload.Entry[0].ID
 		return h.Backend().GetChannelByAddress(ctx, courier.ChannelType("IG"), courier.ChannelAddress(channelAddress))
 	} else {
-		if len(payload.Entry[0].Changes) == 0 {
+		routing := routeWhatsAppChanges(payload)
+		if !routing.hasChanges {
 			return nil, fmt.Errorf("no changes found")
 		}
-		if integrationWebhookFields[payload.Entry[0].Changes[0].Field] {
-			logrus.WithField("field", payload.Entry[0].Changes[0].Field).Info("[integration_webhook] receiving integration webhook")
-			er := handlers.SendWebhooks(r, h.Server().Config().WhatsappCloudWebhooksUrl, "", true)
-			if er != nil {
+
+		if routing.toIntegrations {
+			logrus.Info("[integration_webhook] receiving integration webhook")
+			if er := handlers.SendWebhooks(r, h.Server().Config().WhatsappCloudWebhooksUrl, "", true); er != nil {
 				courier.LogRequestError(r, nil, fmt.Errorf("could not send template webhook: %s", er))
 			}
-
-			if payload.Entry[0].Changes[0].Field == "account_update" {
-				logrus.WithField("event", payload.Entry[0].Changes[0].Value.Event).WithField("waba_info", payload.Entry[0].Changes[0].Value.WabaInfo).Info("[account_update] receiving account_update webhook")
-				// Handle account_update webhook type
-				if payload.Entry[0].Changes[0].Value.Event == "MM_LITE_TERMS_SIGNED" && payload.Entry[0].Changes[0].Value.WabaInfo != nil {
-					logrus.WithField("waba_id", payload.Entry[0].Changes[0].Value.WabaInfo.WabaID).Info("[mmlite] MM_LITE_TERMS_SIGNED event detected for waba_id")
-					wabaID := payload.Entry[0].Changes[0].Value.WabaInfo.WabaID
-
-					// Update channel config with ad_account_id and mmlite for all channels with matching waba_id
-					err := h.Backend().UpdateChannelConfigByWabaID(ctx, wabaID, map[string]interface{}{
-						"mmlite": true,
-					})
-					if err != nil {
-						logrus.WithError(err).WithField("waba_id", wabaID).Error("[mmlite] error updating channel config with waba_id")
-						return nil, fmt.Errorf("error updating channel config with waba_id %s: %v", wabaID, err)
-					}
-					logrus.WithField("waba_id", wabaID).Info("[mmlite] channel config updated with waba_id")
-				}
+			if err := h.handleMMLiteTermsSigned(ctx, payload); err != nil {
+				return nil, err
 			}
-
-			return nil, fmt.Errorf("template update, so ignore")
-		} else if payload.Entry[0].Changes[0].Field == "flows" {
-			er := handlers.SendWebhooks(r, h.Server().Config().WhatsappCloudWebhooksUrlFlows, h.Server().Config().WhatsappCloudWebhooksTokenFlows, false)
-			if er != nil {
-				courier.LogRequestError(r, nil, fmt.Errorf("could not send template webhook: %s", er))
-			}
-			return nil, fmt.Errorf("template update, so ignore")
 		}
-		if payload.Entry[0].Changes[0].Value.Metadata == nil {
+
+		if routing.toFlows {
+			if er := handlers.SendWebhooks(r, h.Server().Config().WhatsappCloudWebhooksUrlFlows, h.Server().Config().WhatsappCloudWebhooksTokenFlows, false); er != nil {
+				courier.LogRequestError(r, nil, fmt.Errorf("could not send flows webhook: %s", er))
+			}
+		}
+
+		if routing.channelAddress == "" {
+			if routing.toIntegrations || routing.toFlows {
+				return nil, fmt.Errorf("template update, so ignore")
+			}
 			return nil, fmt.Errorf("no channel address found")
 		}
-		channelAddress = payload.Entry[0].Changes[0].Value.Metadata.PhoneNumberID
-		if channelAddress == "" {
-			return nil, fmt.Errorf("no channel address found")
+
+		if routing.multipleAddrs {
+			logrus.WithField("phone_number_id", routing.channelAddress).
+				Warn("batched webhook carries more than one phone_number_id; resolving the first")
 		}
+
+		channelAddress = routing.channelAddress
 
 		// get a value if exists from request header to a variable routerToken
 		routerToken := r.Header.Get("X-Router-Token")
@@ -894,6 +925,23 @@ func (h *handler) GetChannel(ctx context.Context, r *http.Request) (courier.Chan
 
 		return h.Backend().GetChannelByAddress(ctx, courier.ChannelType("WAC"), courier.ChannelAddress(channelAddress))
 	}
+}
+
+func (h *handler) handleMMLiteTermsSigned(ctx context.Context, payload *moPayload) error {
+	for _, entry := range payload.Entry {
+		for _, change := range entry.Changes {
+			if change.Field != "account_update" || change.Value.Event != "MM_LITE_TERMS_SIGNED" || change.Value.WabaInfo == nil {
+				continue
+			}
+			wabaID := change.Value.WabaInfo.WabaID
+			if err := h.Backend().UpdateChannelConfigByWabaID(ctx, wabaID, map[string]interface{}{"mmlite": true}); err != nil {
+				logrus.WithError(err).WithField("waba_id", wabaID).Error("[mmlite] error updating channel config with waba_id")
+				return fmt.Errorf("error updating channel config with waba_id %s: %v", wabaID, err)
+			}
+			logrus.WithField("waba_id", wabaID).Info("[mmlite] channel config updated with waba_id")
+		}
+	}
+	return nil
 }
 
 // receiveVerify handles Facebook's webhook verification callback

--- a/handlers/facebookapp/facebookapp_test.go
+++ b/handlers/facebookapp/facebookapp_test.go
@@ -2116,6 +2116,123 @@ func TestWaTemplateTypeFromMetadata(t *testing.T) {
 	}
 }
 
+func TestRouteWhatsAppChanges(t *testing.T) {
+	cases := []struct {
+		label              string
+		payload            string
+		wantHasChanges     bool
+		wantToIntegrations bool
+		wantToFlows        bool
+		wantChannelAddress string
+		wantMultipleAddrs  bool
+	}{
+		{
+			label: "template status update alone",
+			payload: `{
+				"entry":[{"changes":[{"field":"message_template_status_update","value":{}}]}]
+			}`,
+			wantHasChanges:     true,
+			wantToIntegrations: true,
+		},
+		{
+			label: "messages change alone",
+			payload: `{
+				"entry":[{"changes":[{"field":"messages","value":{"metadata":{"phone_number_id":"12345"}}}]}]
+			}`,
+			wantHasChanges:     true,
+			wantChannelAddress: "12345",
+		},
+		{
+			label: "messages then template status in same entry",
+			payload: `{
+				"entry":[{
+					"changes":[
+						{"field":"messages","value":{"metadata":{"phone_number_id":"12345"}}},
+						{"field":"message_template_status_update","value":{}}
+					]
+				}]
+			}`,
+			wantHasChanges:     true,
+			wantToIntegrations: true,
+			wantChannelAddress: "12345",
+		},
+		{
+			label: "template status in entry 0 and messages in entry 1",
+			payload: `{
+				"entry":[
+					{"changes":[{"field":"message_template_status_update","value":{}}]},
+					{"changes":[{"field":"messages","value":{"metadata":{"phone_number_id":"12345"}}}]}
+				]
+			}`,
+			wantHasChanges:     true,
+			wantToIntegrations: true,
+			wantChannelAddress: "12345",
+		},
+		{
+			label: "nil metadata does not panic",
+			payload: `{
+				"entry":[{"changes":[{"field":"messages","value":{}}]}]
+			}`,
+			wantHasChanges: true,
+		},
+		{
+			label: "two different phone_number_ids",
+			payload: `{
+				"entry":[{
+					"changes":[
+						{"field":"messages","value":{"metadata":{"phone_number_id":"111"}}},
+						{"field":"messages","value":{"metadata":{"phone_number_id":"222"}}}
+					]
+				}]
+			}`,
+			wantHasChanges:     true,
+			wantChannelAddress: "111",
+			wantMultipleAddrs:  true,
+		},
+		{
+			label:          "empty entries",
+			payload:        `{"entry":[]}`,
+			wantHasChanges: false,
+		},
+		{
+			label: "entries with no changes",
+			payload: `{
+				"entry":[{"id":"1","changes":[]}]
+			}`,
+			wantHasChanges: false,
+		},
+		{
+			label: "flows mixed with template status update",
+			payload: `{
+				"entry":[{
+					"changes":[
+						{"field":"flows","value":{}},
+						{"field":"message_template_status_update","value":{}}
+					]
+				}]
+			}`,
+			wantHasChanges:     true,
+			wantToIntegrations: true,
+			wantToFlows:        true,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.label, func(t *testing.T) {
+			payload := &moPayload{}
+			err := json.Unmarshal([]byte(c.payload), payload)
+			assert.NoError(t, err)
+
+			got := routeWhatsAppChanges(payload)
+			assert.Equal(t, c.wantHasChanges, got.hasChanges)
+			assert.Equal(t, c.wantToIntegrations, got.toIntegrations)
+			assert.Equal(t, c.wantToFlows, got.toFlows)
+			assert.Equal(t, c.wantChannelAddress, got.channelAddress)
+			assert.Equal(t, c.wantMultipleAddrs, got.multipleAddrs)
+		})
+	}
+}
+
 func TestContactUsernameUpdate(t *testing.T) {
 	channel := courier.NewMockChannel(
 		"8eb23e93-5ecb-45ba-b726-3b064e0c568c",

--- a/handlers/webhook.go
+++ b/handlers/webhook.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io"
 	"net/http"
 	"net/url"
 
@@ -118,11 +117,10 @@ func SendWebhooks(r *http.Request, url_ string, tokenFlows string, isIntegration
 		url_ = parsedURL.String()
 	}
 
-	body, err := io.ReadAll(r.Body)
+	body, err := ReadBody(r, 1000000)
 	if err != nil {
 		return err
 	}
-	defer r.Body.Close()
 
 	// try to decode our envelope
 	if err := json.Unmarshal(body, moTemplatesPayload); err != nil {

--- a/handlers/webhook_test.go
+++ b/handlers/webhook_test.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -63,6 +64,7 @@ func TestSendWebhooks(t *testing.T) {
 		w.WriteHeader(http.StatusOK)
 		w.Write([]byte(`{"data": "success"}`))
 	}))
+	defer ts.Close()
 
 	jsonBody, err := json.Marshal(moTemplatesPayload{})
 	assert.NoError(t, err)
@@ -70,4 +72,22 @@ func TestSendWebhooks(t *testing.T) {
 
 	err = SendWebhooks(req, ts.URL, "", true)
 	assert.NoError(t, err)
+}
+
+func TestSendWebhooksRestoresBody(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"data": "success"}`))
+	}))
+	defer ts.Close()
+
+	originalBody := []byte(`{"object":"whatsapp_business_account","entry":[{"id":"1","changes":[{"field":"messages","value":{}}]}]}`)
+	req := httptest.NewRequest(http.MethodPost, "https://foo.bar/webhook", strings.NewReader(string(originalBody)))
+
+	err := SendWebhooks(req, ts.URL, "", true)
+	assert.NoError(t, err)
+
+	restored, err := io.ReadAll(req.Body)
+	assert.NoError(t, err)
+	assert.Equal(t, originalBody, restored)
 }


### PR DESCRIPTION
- Introduced `routeWhatsAppChanges` to scan all entries and changes in a `whatsapp_business_account` payload, determining whether events should be routed to integrations, flows, or a specific channel address. This replaces the previous logic that only inspected the first entry and first change.
- Extracted `handleMMLiteTermsSigned` into its own method, iterating over all entries and changes to handle `MM_LITE_TERMS_SIGNED` account update events rather than relying solely on the first change.
- Updated `GetChannel` to use `routeWhatsAppChanges`, allowing batched webhook payloads that mix integration events and message events to be handled correctly. A warning is logged when a batched payload carries more than one `phone_number_id`.
- Replaced `io.ReadAll` in `SendWebhooks` with `ReadBody`, which restores the request body after reading so subsequent handlers can still consume it.
- Added `TestRouteWhatsAppChanges` covering scenarios including template-only payloads, mixed entries, nil metadata, multiple phone number IDs, empty entries, and flows combined with template status updates.
- Added `TestSendWebhooksRestoresBody` to verify that the request body remains readable after `SendWebhooks` is called.